### PR TITLE
Add fix-ci mode: fix CI failures from PR check annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ autopilot start --prompt "..."           # Start a new task
 autopilot start --prompt "..." --plan    # Let agent plan + implement
 autopilot start --issue 12345            # Start from a GitHub issue
 autopilot resume --pr 42345              # Resume from an existing PR
+autopilot fix-ci --pr 42345              # Fix CI failures (interactive check selection)
+autopilot fix-ci --pr 42345 --checks "build-ubuntu,test-integration"  # Non-interactive
 autopilot status                          # Show all task statuses
 autopilot logs                            # Show latest task log
 autopilot logs --session abc123           # Show specific task log
@@ -70,7 +72,10 @@ Create `autopilot.json` in your repo root or `~/.autopilot-loop/config.json`:
   "keepalive_enabled": false,
   "keepalive_interval_seconds": 300,
   "branch_pattern": "autopilot/{task_id}",
-  "custom_instructions": "Run tests with: bin/rails test <path>\nRun linting with: bin/rubocop <path>"
+  "custom_instructions": "Run tests with: npm test\nRun linting with: npm run lint",
+  "ci_check_names": [],
+  "ci_poll_interval_seconds": 120,
+  "ci_poll_timeout_seconds": 5400
 }
 ```
 
@@ -82,7 +87,7 @@ All values have sensible defaults — config file is optional.
 - **tmux** (pre-installed in most Codespaces; `apt install tmux` elsewhere)
 - **Python 3.8+**
 
-Codespace idle timeout is set automatically at startup (120 min, org-capped).
+Codespace idle timeout is set automatically at startup (120 min default, subject to your organization's limits).
 
 ## Local Development
 

--- a/autopilot.example.json
+++ b/autopilot.example.json
@@ -10,5 +10,8 @@
   "keepalive_enabled": false,
   "keepalive_interval_seconds": 300,
   "branch_pattern": "autopilot/{task_id}",
-  "custom_instructions": ""
+  "custom_instructions": "",
+  "ci_check_names": [],
+  "ci_poll_interval_seconds": 120,
+  "ci_poll_timeout_seconds": 5400
 }

--- a/src/autopilot_loop/cli.py
+++ b/src/autopilot_loop/cli.py
@@ -4,6 +4,7 @@ Subcommands: start, resume, status, logs, stop, _run (internal).
 """
 
 import argparse
+import json
 import logging
 import os
 import subprocess
@@ -112,8 +113,6 @@ def cmd_start(args):
 
 def cmd_run(args):
     """Internal: run the orchestrator for a task (called from tmux)."""
-    from autopilot_loop.orchestrator import Orchestrator
-
     task = get_task(args.task_id)
     if not task:
         print("Error: task %s not found" % args.task_id, file=sys.stderr)
@@ -128,7 +127,15 @@ def cmd_run(args):
     file_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
     logging.getLogger().addHandler(file_handler)
 
-    orch = Orchestrator(task_id=args.task_id, config=config)
+    # Dispatch to the right orchestrator based on task mode
+    task_mode = task.get("task_mode", "review")
+    if task_mode == "ci":
+        from autopilot_loop.orchestrator import CIOrchestrator
+        orch = CIOrchestrator(task_id=args.task_id, config=config)
+    else:
+        from autopilot_loop.orchestrator import Orchestrator
+        orch = Orchestrator(task_id=args.task_id, config=config)
+
     result = orch.run()
 
     if result.get("state") == "COMPLETE":
@@ -253,6 +260,123 @@ def cmd_logs(args):
                     print("  %s" % name)
 
 
+def cmd_fix_ci(args):
+    """Fix CI failures on an existing PR."""
+    from autopilot_loop.github_api import get_failed_checks
+
+    config = load_config({
+        "model": args.model,
+        "max_iterations": args.max_iters,
+    })
+
+    # Validate PR exists and get branch
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(args.pr), "--json", "headRefName", "--jq", ".headRefName"],
+            capture_output=True, text=True, check=True,
+        )
+        branch = result.stdout.strip()
+        subprocess.run(["git", "checkout", branch], check=True)
+    except subprocess.CalledProcessError as e:
+        print("Error: could not fetch PR #%d: %s" % (args.pr, e), file=sys.stderr)
+        sys.exit(1)
+
+    # Get failed checks
+    failed_checks = get_failed_checks(args.pr)
+    if not failed_checks:
+        print("No failed CI checks found on PR #%d" % args.pr)
+        return
+
+    # Determine which checks to fix
+    if args.checks:
+        # Non-interactive: substring match
+        patterns = [p.strip() for p in args.checks.split(",")]
+        selected = [c for c in failed_checks if any(p in c["name"] for p in patterns)]
+        if not selected:
+            print("No failed checks matched: %s" % args.checks, file=sys.stderr)
+            print("Available failed checks:")
+            for c in failed_checks:
+                print("  %s" % c["name"])
+            sys.exit(1)
+    elif config.get("ci_check_names"):
+        # Pre-configured in config
+        patterns = config["ci_check_names"]
+        selected = [c for c in failed_checks if any(p in c["name"] for p in patterns)]
+        if not selected:
+            print("No failed checks matched ci_check_names config: %s" % patterns, file=sys.stderr)
+            sys.exit(1)
+    else:
+        # Interactive: list and prompt
+        print("Failed CI checks on PR #%d:" % args.pr)
+        print()
+        for i, c in enumerate(failed_checks, 1):
+            print("  %d. %s" % (i, c["name"]))
+        print()
+
+        try:
+            selection = input("Which checks to fix? (comma-separated numbers, or 'all'): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nAborted.")
+            sys.exit(1)
+
+        if selection.lower() == "all":
+            selected = list(failed_checks)
+        else:
+            try:
+                indices = [int(s.strip()) for s in selection.split(",")]
+                selected = [failed_checks[i - 1] for i in indices if 1 <= i <= len(failed_checks)]
+            except (ValueError, IndexError):
+                print("Error: invalid selection", file=sys.stderr)
+                sys.exit(1)
+
+        if not selected:
+            print("No checks selected.")
+            return
+
+    check_names = [c["name"] for c in selected]
+    print("\u2713 Selected %d checks:" % len(selected))
+    for name in check_names:
+        print("  \u2022 %s" % name)
+
+    task_id = _generate_task_id()
+    from autopilot_loop.persistence import update_task
+
+    create_task(
+        task_id=task_id,
+        prompt="(fix-ci for PR #%d)" % args.pr,
+        max_iterations=config["max_iterations"],
+        model=config["model"],
+    )
+    update_task(
+        task_id,
+        pr_number=args.pr,
+        branch=branch,
+        state="FETCH_ANNOTATIONS",
+        task_mode="ci",
+        ci_check_names=json.dumps(check_names),
+    )
+
+    # Launch in tmux
+    sessions_dir = get_sessions_dir(task_id)
+    log_file = os.path.join(sessions_dir, "orchestrator.log")
+    tmux_session = "autopilot-%s" % task_id
+    run_cmd = "autopilot _run --task-id %s 2>&1 | tee -a %s" % (task_id, log_file)
+
+    try:
+        subprocess.run(
+            ["tmux", "new-session", "-d", "-s", tmux_session, run_cmd],
+            check=True,
+        )
+    except FileNotFoundError:
+        logger.warning("tmux not found, running in foreground")
+        cmd_run(argparse.Namespace(task_id=task_id))
+        return
+
+    print("\u2713 Fixing CI on PR #%d as task %s" % (args.pr, task_id))
+    print("\u2713 Branch: %s" % branch)
+    print("\u2713 Running in tmux session: %s" % tmux_session)
+
+
 def cmd_stop(args):
     """Stop a running task."""
     task_id = args.task_id
@@ -309,6 +433,13 @@ def main():
     p_stop = subparsers.add_parser("stop", help="Stop a running task")
     p_stop.add_argument("task_id", type=str, help="Task ID to stop")
 
+    # fix-ci
+    p_fixci = subparsers.add_parser("fix-ci", help="Fix CI failures on an existing PR")
+    p_fixci.add_argument("--pr", type=int, required=True, help="PR number")
+    p_fixci.add_argument("--checks", type=str, help="Comma-separated check names (substring match)")
+    p_fixci.add_argument("--max-iters", type=int, help="Max fix iterations")
+    p_fixci.add_argument("--model", type=str, help="Model override")
+
     # _run (internal, called from tmux)
     p_run = subparsers.add_parser("_run", help=argparse.SUPPRESS)
     p_run.add_argument("--task-id", required=True, help=argparse.SUPPRESS)
@@ -326,6 +457,8 @@ def main():
         cmd_logs(args)
     elif args.command == "stop":
         cmd_stop(args)
+    elif args.command == "fix-ci":
+        cmd_fix_ci(args)
     elif args.command == "_run":
         cmd_run(args)
     else:

--- a/src/autopilot_loop/config.py
+++ b/src/autopilot_loop/config.py
@@ -25,6 +25,9 @@ DEFAULTS = {
     "keepalive_interval_seconds": 300,
     "branch_pattern": "autopilot/{task_id}",
     "custom_instructions": "",
+    "ci_check_names": [],
+    "ci_poll_interval_seconds": 120,
+    "ci_poll_timeout_seconds": 5400,
 }
 
 CONFIG_FILENAMES = [

--- a/src/autopilot_loop/github_api.py
+++ b/src/autopilot_loop/github_api.py
@@ -6,6 +6,7 @@ and inline comment fetching.
 
 import json
 import logging
+import re
 import subprocess
 
 logger = logging.getLogger(__name__)
@@ -13,7 +14,10 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "GitHubAPIError",
     "find_pr_for_branch",
+    "get_check_annotations",
+    "get_check_states",
     "get_copilot_review",
+    "get_failed_checks",
     "get_head_sha",
     "get_issue",
     "get_repo_nwo",
@@ -281,3 +285,136 @@ def get_unresolved_review_comments(pr_number):
         })
 
     return comments
+
+
+# --- CI check functions ---
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text):
+    """Remove ANSI escape codes from text."""
+    return _ANSI_RE.sub("", text)
+
+
+def get_failed_checks(pr_number):
+    """Get failed CI checks for a PR.
+
+    Excludes aggregation gate checks (names ending in '-results').
+    Parses run_id and job_id from the check link URL.
+
+    Returns:
+        List of dicts with {name, link, run_id, job_id}.
+    """
+    output = _run_gh([
+        "pr", "checks", str(pr_number),
+        "--json", "name,state,link",
+        "--jq", '[.[] | select(.state == "FAILURE")]',
+    ], check=False)
+
+    if not output:
+        return []
+
+    raw_checks = json.loads(output)
+    checks = []
+    for c in raw_checks:
+        name = c.get("name", "")
+        # Skip aggregation gates (e.g., "build-results", "test-results")
+        if name.endswith("-results"):
+            continue
+
+        link = c.get("link", "")
+        run_id = None
+        job_id = None
+        # Parse from URL: /actions/runs/{run_id}/job/{job_id}
+        m = re.search(r"/actions/runs/(\d+)/job/(\d+)", link)
+        if m:
+            run_id = int(m.group(1))
+            job_id = int(m.group(2))
+
+        checks.append({
+            "name": name,
+            "link": link,
+            "run_id": run_id,
+            "job_id": job_id,
+        })
+
+    return checks
+
+
+def get_check_annotations(job_ids):
+    """Fetch failure annotations for CI jobs.
+
+    Calls /check-runs/{id}/annotations for each job, filters to
+    annotation_level == 'failure', deduplicates by (path, start_line),
+    strips ANSI codes, and excludes generic 'Process completed' messages.
+
+    Args:
+        job_ids: List of job IDs (ints).
+
+    Returns:
+        List of dicts with {path, start_line, end_line, title, message}.
+    """
+    nwo = get_repo_nwo()
+    seen = set()  # (path, start_line) for dedup
+    annotations = []
+
+    for job_id in job_ids:
+        output = _run_gh([
+            "api", "repos/%s/check-runs/%d/annotations" % (nwo, job_id),
+        ], check=False)
+
+        if not output:
+            continue
+
+        raw = json.loads(output)
+        for ann in raw:
+            if ann.get("annotation_level") != "failure":
+                continue
+
+            path = ann.get("path", "")
+            start_line = ann.get("start_line", 0)
+            message = _strip_ansi(ann.get("message", ""))
+            title = _strip_ansi(ann.get("title", ""))
+
+            # Skip generic "Process completed with exit code N" messages
+            if message.startswith("Process completed with exit code"):
+                continue
+
+            key = (path, start_line)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            annotations.append({
+                "path": path,
+                "start_line": start_line,
+                "end_line": ann.get("end_line", start_line),
+                "title": title,
+                "message": message,
+            })
+
+    return annotations[:50]  # Cap to avoid prompt bloat
+
+
+def get_check_states(pr_number, check_names):
+    """Get the current state of specific checks on a PR.
+
+    Args:
+        pr_number: PR number.
+        check_names: List of check names to query.
+
+    Returns:
+        Dict mapping check name to state string (e.g., 'SUCCESS', 'FAILURE', 'PENDING').
+    """
+    output = _run_gh([
+        "pr", "checks", str(pr_number),
+        "--json", "name,state",
+    ], check=False)
+
+    if not output:
+        return {name: "UNKNOWN" for name in check_names}
+
+    raw = json.loads(output)
+    state_map = {c["name"]: c["state"] for c in raw}
+    return {name: state_map.get(name, "UNKNOWN") for name in check_names}

--- a/src/autopilot_loop/orchestrator.py
+++ b/src/autopilot_loop/orchestrator.py
@@ -1,8 +1,11 @@
-"""Core state machine orchestrator.
+"""Core state machine orchestrators.
 
-Manages the full lifecycle: INIT → IMPLEMENT → VERIFY_PR → REQUEST_REVIEW →
+Orchestrator: INIT → IMPLEMENT → VERIFY_PR → REQUEST_REVIEW →
 WAIT_REVIEW → PARSE_REVIEW → FIX → VERIFY_PUSH → RESOLVE_COMMENTS →
 REQUEST_REVIEW → ... → COMPLETE.
+
+CIOrchestrator: INIT → FETCH_ANNOTATIONS → FIX_CI → VERIFY_PUSH →
+WAIT_CI → FETCH_ANNOTATIONS → ... → COMPLETE.
 """
 
 import json
@@ -14,7 +17,10 @@ from autopilot_loop.agent import run_agent
 from autopilot_loop.codespace import set_idle_timeout
 from autopilot_loop.github_api import (
     find_pr_for_branch,
+    get_check_annotations,
+    get_check_states,
     get_copilot_review,
+    get_failed_checks,
     get_head_sha,
     get_unresolved_review_comments,
     is_copilot_review_complete,
@@ -31,7 +37,9 @@ from autopilot_loop.persistence import (
     update_task,
 )
 from autopilot_loop.prompts import (
+    fix_ci_prompt,
     fix_prompt,
+    format_ci_annotations_for_prompt,
     format_review_for_prompt,
     implement_prompt,
     plan_and_implement_prompt,
@@ -39,7 +47,7 @@ from autopilot_loop.prompts import (
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["Orchestrator"]
+__all__ = ["Orchestrator", "CIOrchestrator"]
 
 # Valid state transitions
 STATES = [
@@ -58,8 +66,8 @@ STATES = [
 ]
 
 
-class Orchestrator:
-    """State machine orchestrator for the autopilot loop."""
+class BaseOrchestrator:
+    """Shared infrastructure for state machine orchestrators."""
 
     def __init__(self, task_id, config):
         self.task_id = task_id
@@ -67,7 +75,10 @@ class Orchestrator:
         self.task = get_task(task_id)
         self.sessions_dir = get_sessions_dir(task_id)
         self._retry_counts = {}  # phase -> retry count
-        self._last_review_id = self.task.get("last_review_id")  # restore from DB
+
+    def _get_handlers(self):
+        """Return a dict mapping state names to handler methods. Subclasses must override."""
+        raise NotImplementedError
 
     def run(self):
         """Run the state machine until COMPLETE or FAILED."""
@@ -90,41 +101,29 @@ class Orchestrator:
 
     def _transition(self, state):
         """Execute the current state and return the next state."""
-        handler = {
-            "INIT": self._do_init,
-            "PLAN_AND_IMPLEMENT": self._do_plan_and_implement,
-            "IMPLEMENT": self._do_implement,
-            "VERIFY_PR": self._do_verify_pr,
-            "REQUEST_REVIEW": self._do_request_review,
-            "WAIT_REVIEW": self._do_wait_review,
-            "PARSE_REVIEW": self._do_parse_review,
-            "FIX": self._do_fix,
-            "VERIFY_PUSH": self._do_verify_push,
-            "RESOLVE_COMMENTS": self._do_resolve_comments,
-        }.get(state)
-
+        handler = self._get_handlers().get(state)
         if handler is None:
             logger.error("[%s] Unknown state: %s", self.task_id, state)
             return "FAILED"
-
         return handler()
 
     def _do_init(self):
         """Validate config, create session dir, set codespace idle timeout."""
-        logger.info("[%s] INIT → Validated config, created session dir", self.task_id)
+        logger.info("[%s] INIT \u2192 Validated config, created session dir", self.task_id)
 
         # Set codespace idle timeout (non-fatal)
         try:
             set_idle_timeout(self.config.get("idle_timeout_minutes", 120))
-            logger.info("[%s] ✓ Codespace idle timeout set to %d minutes",
+            logger.info("[%s] \u2713 Codespace idle timeout set to %d minutes",
                         self.task_id, self.config.get("idle_timeout_minutes", 120))
         except Exception as e:
             logger.warning("[%s] Could not set codespace idle timeout: %s", self.task_id, e)
 
-        # Determine next state
-        if self.task.get("plan_mode"):
-            return "PLAN_AND_IMPLEMENT"
-        return "IMPLEMENT"
+        return self._init_next_state()
+
+    def _init_next_state(self):
+        """Return the state to transition to after INIT. Subclasses must override."""
+        raise NotImplementedError
 
     def _run_agent_with_retry(self, phase, prompt, session_name):
         """Run an agent with retry policy.
@@ -185,6 +184,72 @@ class Orchestrator:
         )
         return None
 
+    def _do_verify_push(self):
+        """Verify new commits were pushed after fix."""
+        branch = self.task["branch"]
+        pre_sha = getattr(self, "_pre_fix_sha", None)
+
+        if pre_sha and verify_new_commits(branch, pre_sha):
+            logger.info("[%s] \u2713 New commits found on %s", self.task_id, branch)
+            return self._after_verify_push()
+
+        # Maybe the agent already pushed and we just need to check
+        new_sha = get_head_sha(branch)
+        if new_sha and new_sha != pre_sha:
+            logger.info("[%s] \u2713 New commits found on %s", self.task_id, branch)
+            return self._after_verify_push()
+
+        # No new commits \u2014 retry FIX once
+        retry_key = "VERIFY_PUSH_FIX_RETRY"
+        if self._retry_counts.get(retry_key, 0) > 0:
+            logger.error("[%s] No new commits on %s after fix retry", self.task_id, branch)
+            return "FAILED"
+
+        logger.warning("[%s] No new commits on %s, retrying fix", self.task_id, branch)
+        self._retry_counts[retry_key] = 1
+        return self._retry_fix_state()
+
+    def _after_verify_push(self):
+        """State to transition to after VERIFY_PUSH succeeds. Subclasses must override."""
+        raise NotImplementedError
+
+    def _retry_fix_state(self):
+        """State to retry when VERIFY_PUSH finds no new commits. Subclasses must override."""
+        raise NotImplementedError
+
+
+class Orchestrator(BaseOrchestrator):
+    """State machine orchestrator for the review-fix autopilot loop."""
+
+    def __init__(self, task_id, config):
+        super().__init__(task_id, config)
+        self._last_review_id = self.task.get("last_review_id")  # restore from DB
+
+    def _get_handlers(self):
+        return {
+            "INIT": self._do_init,
+            "PLAN_AND_IMPLEMENT": self._do_plan_and_implement,
+            "IMPLEMENT": self._do_implement,
+            "VERIFY_PR": self._do_verify_pr,
+            "REQUEST_REVIEW": self._do_request_review,
+            "WAIT_REVIEW": self._do_wait_review,
+            "PARSE_REVIEW": self._do_parse_review,
+            "FIX": self._do_fix,
+            "VERIFY_PUSH": self._do_verify_push,
+            "RESOLVE_COMMENTS": self._do_resolve_comments,
+        }
+
+    def _init_next_state(self):
+        if self.task.get("plan_mode"):
+            return "PLAN_AND_IMPLEMENT"
+        return "IMPLEMENT"
+
+    def _after_verify_push(self):
+        return "RESOLVE_COMMENTS"
+
+    def _retry_fix_state(self):
+        return "FIX"
+
     def _do_implement(self):
         """Run copilot agent with implement prompt."""
         branch = self.task["branch"]
@@ -198,7 +263,7 @@ class Orchestrator:
         if result is None:
             return "FAILED"
 
-        logger.info("[%s] ✓ Agent completed (exit %d, %.1fs)", self.task_id, result.exit_code, result.duration)
+        logger.info("[%s] \u2713 Agent completed (exit %d, %.1fs)", self.task_id, result.exit_code, result.duration)
         return "VERIFY_PR"
 
     def _do_plan_and_implement(self):
@@ -214,7 +279,7 @@ class Orchestrator:
         if result is None:
             return "FAILED"
 
-        logger.info("[%s] ✓ Agent completed (exit %d, %.1fs)", self.task_id, result.exit_code, result.duration)
+        logger.info("[%s] \u2713 Agent completed (exit %d, %.1fs)", self.task_id, result.exit_code, result.duration)
         return "VERIFY_PR"
 
     def _do_verify_pr(self):
@@ -376,33 +441,8 @@ class Orchestrator:
         if result is None:
             return "FAILED"
 
-        logger.info("[%s] ✓ Fix agent completed (exit %d, %.1fs)", self.task_id, result.exit_code, result.duration)
+        logger.info("[%s] \u2713 Fix agent completed (exit %d, %.1fs)", self.task_id, result.exit_code, result.duration)
         return "VERIFY_PUSH"
-
-    def _do_verify_push(self):
-        """Verify new commits were pushed after fix."""
-        branch = self.task["branch"]
-        pre_sha = getattr(self, "_pre_fix_sha", None)
-
-        if pre_sha and verify_new_commits(branch, pre_sha):
-            logger.info("[%s] ✓ New commits found on %s", self.task_id, branch)
-            return "RESOLVE_COMMENTS"
-
-        # Maybe the agent already pushed and we just need to check
-        new_sha = get_head_sha(branch)
-        if new_sha and new_sha != pre_sha:
-            logger.info("[%s] ✓ New commits found on %s", self.task_id, branch)
-            return "RESOLVE_COMMENTS"
-
-        # No new commits — retry FIX once
-        retry_key = "VERIFY_PUSH_FIX_RETRY"
-        if self._retry_counts.get(retry_key, 0) > 0:
-            logger.error("[%s] No new commits on %s after fix retry", self.task_id, branch)
-            return "FAILED"
-
-        logger.warning("[%s] No new commits on %s, retrying FIX", self.task_id, branch)
-        self._retry_counts[retry_key] = 1
-        return "FIX"
 
     def _do_resolve_comments(self):
         """Reply to and resolve review comments based on fix summary."""
@@ -474,5 +514,161 @@ class Orchestrator:
             except Exception as e:
                 logger.warning("[%s] Failed to resolve comment %d: %s", self.task_id, comment_id, e)
 
-        logger.info("[%s] ✓ Resolved %d/%d comments", self.task_id, resolved_count, len(comments))
+        logger.info("[%s] \u2713 Resolved %d/%d comments", self.task_id, resolved_count, len(comments))
         return "REQUEST_REVIEW"
+
+
+class CIOrchestrator(BaseOrchestrator):
+    """State machine orchestrator for fixing CI failures.
+
+    Loop: INIT → FETCH_ANNOTATIONS → FIX_CI → VERIFY_PUSH → WAIT_CI →
+    FETCH_ANNOTATIONS → ... → COMPLETE.
+    """
+
+    def _get_handlers(self):
+        return {
+            "INIT": self._do_init,
+            "FETCH_ANNOTATIONS": self._do_fetch_annotations,
+            "FIX_CI": self._do_fix_ci,
+            "VERIFY_PUSH": self._do_verify_push,
+            "WAIT_CI": self._do_wait_ci,
+        }
+
+    def _init_next_state(self):
+        return "FETCH_ANNOTATIONS"
+
+    def _after_verify_push(self):
+        return "WAIT_CI"
+
+    def _retry_fix_state(self):
+        return "FIX_CI"
+
+    def _do_fetch_annotations(self):
+        """Fetch failure annotations for the selected CI checks."""
+        pr_number = self.task["pr_number"]
+        iteration = self.task["iteration"] + 1
+        max_iterations = self.task["max_iterations"]
+
+        # Get the user-selected check names from the task
+        ci_check_names = json.loads(self.task.get("ci_check_names") or "[]")
+        if not ci_check_names:
+            logger.error("[%s] No CI check names configured", self.task_id)
+            return "FAILED"
+
+        # Get current failed checks to find job IDs
+        all_failed = get_failed_checks(pr_number)
+        selected = [c for c in all_failed if c["name"] in ci_check_names]
+
+        # Collect job IDs for annotation fetching
+        job_ids = [c["job_id"] for c in selected if c.get("job_id")]
+
+        if not job_ids:
+            # Check if the selected checks are now passing
+            states = get_check_states(pr_number, ci_check_names)
+            all_passing = all(s == "SUCCESS" for s in states.values())
+            if all_passing:
+                logger.info("[%s] \u2713 All selected checks are passing!", self.task_id)
+                return "COMPLETE"
+
+            # Checks are in a non-failure state (pending, etc.) or have no job IDs
+            logger.warning("[%s] No job IDs found for selected checks. States: %s", self.task_id, states)
+            return "COMPLETE"
+
+        annotations = get_check_annotations(job_ids)
+
+        # Save annotation data
+        ann_file = os.path.join(self.sessions_dir, "ci-annotations-%d.json" % iteration)
+        with open(ann_file, "w") as f:
+            json.dump(annotations, f, indent=2)
+
+        update_task(self.task_id, iteration=iteration)
+
+        if not annotations:
+            logger.info("[%s] \u2713 No actionable CI annotations found", self.task_id)
+            return "COMPLETE"
+
+        logger.info("[%s] %d CI failure annotations found:", self.task_id, len(annotations))
+        for i, a in enumerate(annotations, 1):
+            logger.info("[%s]   %d. %s:%s \u2014 %s",
+                        self.task_id, i, a.get("path", "?"), a.get("start_line", "?"),
+                        a.get("title", "")[:80])
+
+        if iteration >= max_iterations:
+            logger.warning(
+                "[%s] Reached max iterations (%d/%d) with %d CI failures remaining",
+                self.task_id, iteration, max_iterations, len(annotations),
+            )
+            return "COMPLETE"
+
+        # Store for FIX_CI
+        self._current_annotations = annotations
+        return "FIX_CI"
+
+    def _do_fix_ci(self):
+        """Run copilot agent to fix CI failures."""
+        iteration = self.task["iteration"]
+
+        annotations = getattr(self, "_current_annotations", None)
+        if annotations is None:
+            # Re-fetch if not cached (e.g., after restart)
+            ci_check_names = json.loads(self.task.get("ci_check_names") or "[]")
+            all_failed = get_failed_checks(self.task["pr_number"])
+            selected = [c for c in all_failed if c["name"] in ci_check_names]
+            job_ids = [c["job_id"] for c in selected if c.get("job_id")]
+            annotations = get_check_annotations(job_ids)
+
+        annotations_text = format_ci_annotations_for_prompt(annotations)
+        prompt = fix_ci_prompt(
+            ci_annotations_text=annotations_text,
+            custom_instructions=self.config.get("custom_instructions", ""),
+        )
+
+        self._pre_fix_sha = get_head_sha(self.task["branch"])
+
+        result = self._run_agent_with_retry("FIX_CI", prompt, "fix-ci-%d" % iteration)
+        if result is None:
+            return "FAILED"
+
+        logger.info("[%s] \u2713 CI fix agent completed (exit %d, %.1fs)",
+                    self.task_id, result.exit_code, result.duration)
+        return "VERIFY_PUSH"
+
+    def _do_wait_ci(self):
+        """Poll selected CI checks until they pass or timeout."""
+        pr_number = self.task["pr_number"]
+        ci_check_names = json.loads(self.task.get("ci_check_names") or "[]")
+        poll_interval = self.config.get("ci_poll_interval_seconds", 120)
+        timeout = self.config.get("ci_poll_timeout_seconds", 5400)
+        start_time = time.time()
+
+        logger.info("[%s] Polling %d checks every %ds (timeout: %ds)...",
+                    self.task_id, len(ci_check_names), poll_interval, timeout)
+
+        while True:
+            elapsed = time.time() - start_time
+            if elapsed > timeout:
+                logger.warning(
+                    "[%s] CI poll timed out after %ds",
+                    self.task_id, timeout,
+                )
+                return "COMPLETE"
+
+            states = get_check_states(pr_number, ci_check_names)
+
+            # Check if all selected checks have completed
+            pending = [n for n, s in states.items() if s not in ("SUCCESS", "FAILURE", "ERROR")]
+            failed = [n for n, s in states.items() if s in ("FAILURE", "ERROR")]
+            passed = [n for n, s in states.items() if s == "SUCCESS"]
+
+            if not pending:
+                if not failed:
+                    logger.info("[%s] \u2713 All %d selected checks passed!", self.task_id, len(passed))
+                    return "COMPLETE"
+                else:
+                    logger.info("[%s] %d checks still failing: %s",
+                                self.task_id, len(failed), ", ".join(failed))
+                    return "FETCH_ANNOTATIONS"
+
+            logger.debug("[%s] %d checks pending, %d passed, %d failed (%.0f/%ds elapsed)",
+                         self.task_id, len(pending), len(passed), len(failed), elapsed, timeout)
+            time.sleep(poll_interval)

--- a/src/autopilot_loop/persistence.py
+++ b/src/autopilot_loop/persistence.py
@@ -28,7 +28,7 @@ DB_PATH = os.path.join(DB_DIR, "state.db")
 
 # Bump this when the schema changes. Additive changes (new nullable columns)
 # are handled by _migrate(). Breaking changes trigger a DB recreate.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_meta (
@@ -48,6 +48,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     dry_run INTEGER NOT NULL DEFAULT 0,
     model TEXT,
     last_review_id INTEGER,
+    task_mode TEXT NOT NULL DEFAULT 'review',
+    ci_check_names TEXT,
     created_at REAL NOT NULL,
     updated_at REAL NOT NULL
 );
@@ -77,6 +79,8 @@ CREATE TABLE IF NOT EXISTS agent_runs (
 # Applied in order. Only runs migrations newer than the current DB version.
 _MIGRATIONS = [
     (2, "tasks", "last_review_id", "INTEGER"),
+    (3, "tasks", "task_mode", "TEXT NOT NULL DEFAULT 'review'"),
+    (3, "tasks", "ci_check_names", "TEXT"),
 ]
 
 
@@ -178,7 +182,8 @@ def get_task(task_id):
 
 _TASK_COLUMNS = frozenset({
     "prompt", "state", "pr_number", "branch", "iteration",
-    "max_iterations", "plan_mode", "dry_run", "model", "last_review_id", "updated_at",
+    "max_iterations", "plan_mode", "dry_run", "model", "last_review_id",
+    "task_mode", "ci_check_names", "updated_at",
 })
 
 

--- a/src/autopilot_loop/prompts.py
+++ b/src/autopilot_loop/prompts.py
@@ -8,7 +8,9 @@ __all__ = [
     "implement_prompt",
     "plan_and_implement_prompt",
     "fix_prompt",
+    "fix_ci_prompt",
     "format_review_for_prompt",
+    "format_ci_annotations_for_prompt",
 ]
 
 
@@ -167,5 +169,73 @@ def format_review_for_prompt(review_body, inline_comments):
             parts.append("")
     else:
         parts.append("No inline comments.")
+
+    return "\n".join(parts)
+
+
+def fix_ci_prompt(ci_annotations_text, custom_instructions=""):
+    """Prompt for the FIX_CI phase.
+
+    Agent fixes CI failures based on annotations, runs the full test suite,
+    commits, and pushes.
+    """
+    parts = []
+
+    if custom_instructions:
+        parts.append(custom_instructions.strip())
+        parts.append("")
+
+    parts.append("## CI Failures to Fix")
+    parts.append("")
+    parts.append(ci_annotations_text.strip())
+    parts.append("")
+    parts.append("## Instructions")
+    parts.append(
+        "1. Read each CI failure above. The path and line number point to the\n"
+        "   exact location of the failure. Open the file and understand what broke.\n"
+        "2. Fix the root cause. If multiple failures share the same root cause\n"
+        "   (e.g., a missing test case for a new route), fix it once.\n"
+        "3. Run the full test suite to verify your fixes don't break anything \u2014\n"
+        "   not just the tests that failed. Adjacent test files often break too.\n"
+        "4. Commit with a descriptive message that explains what CI failures\n"
+        "   were addressed. Do NOT use generic messages like 'fix CI'.\n"
+        "   Instead, describe the specific changes.\n"
+        "5. Push the changes.\n"
+        "6. After pushing, review your own fix by running `git diff HEAD~1` and\n"
+        "   examining the output. If you introduced any new issues, fix them,\n"
+        "   commit, and push again.\n"
+    )
+
+    return "\n".join(parts)
+
+
+def format_ci_annotations_for_prompt(annotations):
+    """Format CI failure annotations for the fix_ci prompt.
+
+    Args:
+        annotations: List of dicts with {path, start_line, end_line, title, message}.
+
+    Returns:
+        Formatted string ready to embed in the fix_ci prompt.
+    """
+    if not annotations:
+        return "No CI failure annotations found."
+
+    parts = ["### CI Failure Annotations (%d)" % len(annotations), ""]
+    for i, ann in enumerate(annotations, 1):
+        path = ann.get("path", "unknown")
+        line = ann.get("start_line", "?")
+        title = ann.get("title", "").strip()
+        message = ann.get("message", "").strip()
+
+        parts.append("**Failure %d** \u2014 `%s` (line %s):" % (i, path, line))
+        if title:
+            parts.append("  %s" % title)
+        if message:
+            # Limit message length to avoid prompt bloat
+            if len(message) > 1000:
+                message = message[:1000] + "\n  ... (truncated)"
+            parts.append(message)
+        parts.append("")
 
     return "\n".join(parts)

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -8,7 +8,10 @@ import pytest
 import autopilot_loop.github_api as github_api_module
 from autopilot_loop.github_api import (
     find_pr_for_branch,
+    get_check_annotations,
+    get_check_states,
     get_copilot_review,
+    get_failed_checks,
     get_issue,
     get_repo_nwo,
     get_unresolved_review_comments,
@@ -251,3 +254,97 @@ class TestVerifyNewCommits:
     def test_error_returns_false(self, mock_sha):
         mock_sha.return_value = None
         assert verify_new_commits("branch", "sha") is False
+
+
+class TestGetFailedChecks:
+    def test_returns_failed_non_results(self):
+        checks_json = json.dumps([
+            {"name": "github (4) / github-4", "state": "FAILURE",
+             "link": "https://github.com/o/r/actions/runs/111/job/222"},
+            {"name": "github-results", "state": "FAILURE", "link": ""},
+            {"name": "build-ubuntu (7) / build-ubuntu-7", "state": "FAILURE",
+             "link": "https://github.com/o/r/actions/runs/111/job/333"},
+        ])
+        with patch("autopilot_loop.github_api.subprocess.run", return_value=_mock_run(checks_json)):
+            result = get_failed_checks(42)
+        # Should exclude *-results
+        assert len(result) == 2
+        assert result[0]["name"] == "github (4) / github-4"
+        assert result[0]["run_id"] == 111
+        assert result[0]["job_id"] == 222
+        assert result[1]["job_id"] == 333
+
+    def test_empty_when_no_failures(self):
+        with patch("autopilot_loop.github_api.subprocess.run", return_value=_mock_run("")):
+            assert get_failed_checks(42) == []
+
+    def test_handles_missing_link(self):
+        checks_json = json.dumps([
+            {"name": "custom-check", "state": "FAILURE", "link": "https://example.com/other"},
+        ])
+        with patch("autopilot_loop.github_api.subprocess.run", return_value=_mock_run(checks_json)):
+            result = get_failed_checks(42)
+        assert len(result) == 1
+        assert result[0]["run_id"] is None
+        assert result[0]["job_id"] is None
+
+
+class TestGetCheckAnnotations:
+    def test_returns_failure_annotations_deduped(self):
+        ann1 = json.dumps([
+            {"annotation_level": "failure", "path": "test/a.rb", "start_line": 40,
+             "end_line": 40, "title": "Test failure", "message": "Expected true got false"},
+            {"annotation_level": "warning", "path": ".github", "start_line": 1,
+             "title": "Deprecation", "message": "Node 20 deprecated"},
+            {"annotation_level": "failure", "path": ".github", "start_line": 9999,
+             "title": "", "message": "Process completed with exit code 1."},
+        ])
+        ann2 = json.dumps([
+            # Duplicate of the first annotation (same path + line)
+            {"annotation_level": "failure", "path": "test/a.rb", "start_line": 40,
+             "end_line": 40, "title": "Test failure", "message": "Expected true got false"},
+            {"annotation_level": "failure", "path": "test/b.rb", "start_line": 10,
+             "end_line": 10, "title": "Another failure", "message": "Missing method"},
+        ])
+        with patch("autopilot_loop.github_api._run_gh") as mock_gh:
+            mock_gh.side_effect = [
+                "octocat/hello-world",  # get_repo_nwo (cached after first)
+                ann1,
+                ann2,
+            ]
+            result = get_check_annotations([100, 200])
+        #  Expect 2: a.rb:40 (deduped), b.rb:10. Skipped: warning, "Process completed"
+        assert len(result) == 2
+        assert result[0]["path"] == "test/a.rb"
+        assert result[1]["path"] == "test/b.rb"
+
+    def test_strips_ansi(self):
+        ann = json.dumps([
+            {"annotation_level": "failure", "path": "test/x.rb", "start_line": 1,
+             "end_line": 1, "title": "\x1b[31mRed title\x1b[0m",
+             "message": "\x1b[49;31mcolored\x1b[0m text"},
+        ])
+        with patch("autopilot_loop.github_api._run_gh") as mock_gh:
+            mock_gh.side_effect = ["octocat/hello-world", ann]
+            result = get_check_annotations([100])
+        assert result[0]["title"] == "Red title"
+        assert result[0]["message"] == "colored text"
+
+    def test_empty_when_no_annotations(self):
+        with patch("autopilot_loop.github_api._run_gh") as mock_gh:
+            mock_gh.side_effect = ["octocat/hello-world", ""]
+            assert get_check_annotations([100]) == []
+
+
+class TestGetCheckStates:
+    def test_returns_states_for_selected(self):
+        checks_json = json.dumps([
+            {"name": "check-a", "state": "SUCCESS"},
+            {"name": "check-b", "state": "FAILURE"},
+            {"name": "check-c", "state": "PENDING"},
+        ])
+        with patch("autopilot_loop.github_api.subprocess.run", return_value=_mock_run(checks_json)):
+            result = get_check_states(42, ["check-a", "check-b", "check-d"])
+        assert result["check-a"] == "SUCCESS"
+        assert result["check-b"] == "FAILURE"
+        assert result["check-d"] == "UNKNOWN"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -6,7 +6,7 @@ import pytest
 
 from autopilot_loop import persistence
 from autopilot_loop.agent import AgentResult
-from autopilot_loop.orchestrator import Orchestrator
+from autopilot_loop.orchestrator import CIOrchestrator, Orchestrator
 
 
 @pytest.fixture(autouse=True)
@@ -380,3 +380,173 @@ class TestOrchestratorVerifyPush:
         orch._pre_fix_sha = "same_sha"
         orch._retry_counts["VERIFY_PUSH_FIX_RETRY"] = 1  # Already retried
         assert orch._do_verify_push() == "FAILED"
+
+
+def _create_ci_task(task_id="ci1", check_names=None):
+    import json as _json
+    if check_names is None:
+        check_names = ["build-and-test-7"]
+    persistence.create_task(task_id, "(fix-ci)", max_iterations=3, model="test-model")
+    persistence.update_task(
+        task_id,
+        branch="autopilot/%s" % task_id,
+        pr_number=42,
+        state="FETCH_ANNOTATIONS",
+        task_mode="ci",
+        ci_check_names=_json.dumps(check_names),
+    )
+    return task_id
+
+
+class TestCIOrchestratorFetchAnnotations:
+    @patch("autopilot_loop.orchestrator.get_check_annotations")
+    @patch("autopilot_loop.orchestrator.get_failed_checks")
+    def test_annotations_found_transitions_to_fix(self, mock_failed, mock_ann, config):
+        mock_failed.return_value = [
+            {"name": "build-and-test-7", "job_id": 100, "run_id": 1, "link": ""},
+        ]
+        mock_ann.return_value = [
+            {"path": "test/a.rb", "start_line": 40, "end_line": 40,
+             "title": "Test failure", "message": "assert failed"},
+        ]
+        task_id = _create_ci_task()
+        orch = CIOrchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        assert orch._do_fetch_annotations() == "FIX_CI"
+
+    @patch("autopilot_loop.orchestrator.get_check_annotations")
+    @patch("autopilot_loop.orchestrator.get_failed_checks")
+    def test_no_annotations_completes(self, mock_failed, mock_ann, config):
+        mock_failed.return_value = [
+            {"name": "build-and-test-7", "job_id": 100, "run_id": 1, "link": ""},
+        ]
+        mock_ann.return_value = []
+        task_id = _create_ci_task()
+        orch = CIOrchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        assert orch._do_fetch_annotations() == "COMPLETE"
+
+    @patch("autopilot_loop.orchestrator.get_check_states")
+    @patch("autopilot_loop.orchestrator.get_failed_checks")
+    def test_checks_now_passing_completes(self, mock_failed, mock_states, config):
+        mock_failed.return_value = []  # No longer failing
+        mock_states.return_value = {"build-and-test-7": "SUCCESS"}
+        task_id = _create_ci_task()
+        orch = CIOrchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        assert orch._do_fetch_annotations() == "COMPLETE"
+
+    @patch("autopilot_loop.orchestrator.get_check_annotations")
+    @patch("autopilot_loop.orchestrator.get_failed_checks")
+    def test_max_iterations_completes(self, mock_failed, mock_ann, config):
+        mock_failed.return_value = [
+            {"name": "build-and-test-7", "job_id": 100, "run_id": 1, "link": ""},
+        ]
+        mock_ann.return_value = [
+            {"path": "test/a.rb", "start_line": 40, "end_line": 40,
+             "title": "Test failure", "message": "still failing"},
+        ]
+        task_id = _create_ci_task()
+        persistence.update_task(task_id, iteration=3)  # At max
+        orch = CIOrchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        assert orch._do_fetch_annotations() == "COMPLETE"
+
+
+class TestCIOrchestratorFixCI:
+    @patch("autopilot_loop.orchestrator.get_head_sha")
+    @patch("autopilot_loop.orchestrator.run_agent")
+    def test_fix_ci_success(self, mock_run, mock_sha, config):
+        mock_run.return_value = _mock_agent_result()
+        mock_sha.return_value = "abc123"
+        task_id = _create_ci_task()
+        orch = CIOrchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        orch._current_annotations = [
+            {"path": "test/a.rb", "start_line": 40, "title": "fail", "message": "msg"},
+        ]
+        assert orch._do_fix_ci() == "VERIFY_PUSH"
+
+
+class TestCIOrchestratorWaitCI:
+    @patch("autopilot_loop.orchestrator.get_check_states")
+    def test_all_checks_pass(self, mock_states, config):
+        mock_states.return_value = {"build-and-test-7": "SUCCESS"}
+        task_id = _create_ci_task()
+        orch = CIOrchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        assert orch._do_wait_ci() == "COMPLETE"
+
+    @patch("autopilot_loop.orchestrator.get_check_states")
+    def test_checks_still_failing(self, mock_states, config):
+        mock_states.return_value = {"build-and-test-7": "FAILURE"}
+        task_id = _create_ci_task()
+        orch = CIOrchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        assert orch._do_wait_ci() == "FETCH_ANNOTATIONS"
+
+    @patch("autopilot_loop.orchestrator.time.sleep")
+    @patch("autopilot_loop.orchestrator.get_check_states")
+    def test_timeout_completes(self, mock_states, mock_sleep, config):
+        mock_states.return_value = {"build-and-test-7": "PENDING"}
+        config["ci_poll_timeout_seconds"] = 0  # Immediate timeout
+        task_id = _create_ci_task()
+        orch = CIOrchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        assert orch._do_wait_ci() == "COMPLETE"
+
+
+class TestCIOrchestratorVerifyPush:
+    @patch("autopilot_loop.orchestrator.get_head_sha")
+    @patch("autopilot_loop.orchestrator.verify_new_commits")
+    def test_goes_to_wait_ci(self, mock_verify, mock_sha, config):
+        """CIOrchestrator VERIFY_PUSH transitions to WAIT_CI (not RESOLVE_COMMENTS)."""
+        mock_verify.return_value = True
+        task_id = _create_ci_task()
+        orch = CIOrchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        orch._pre_fix_sha = "old_sha"
+        assert orch._do_verify_push() == "WAIT_CI"
+
+    @patch("autopilot_loop.orchestrator.get_head_sha")
+    @patch("autopilot_loop.orchestrator.verify_new_commits")
+    def test_no_commits_retries_fix_ci(self, mock_verify, mock_sha, config):
+        """CIOrchestrator VERIFY_PUSH retries FIX_CI (not FIX)."""
+        mock_verify.return_value = False
+        mock_sha.return_value = "same"
+        task_id = _create_ci_task()
+        orch = CIOrchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        orch._pre_fix_sha = "same"
+        assert orch._do_verify_push() == "FIX_CI"
+
+
+class TestCIOrchestratorFullLoop:
+    @patch("autopilot_loop.orchestrator.set_idle_timeout")
+    @patch("autopilot_loop.orchestrator.get_check_states")
+    @patch("autopilot_loop.orchestrator.verify_new_commits")
+    @patch("autopilot_loop.orchestrator.get_head_sha")
+    @patch("autopilot_loop.orchestrator.run_agent")
+    @patch("autopilot_loop.orchestrator.get_check_annotations")
+    @patch("autopilot_loop.orchestrator.get_failed_checks")
+    def test_fix_then_pass(
+        self, mock_failed, mock_ann, mock_run, mock_sha, mock_verify,
+        mock_states, mock_timeout, config,
+    ):
+        """Full CI loop: fetch annotations → fix → verify push → wait CI → COMPLETE."""
+        mock_failed.return_value = [
+            {"name": "build-and-test-7", "job_id": 100, "run_id": 1, "link": ""},
+        ]
+        mock_ann.return_value = [
+            {"path": "test/a.rb", "start_line": 40, "end_line": 40,
+             "title": "Test failure", "message": "assert failed"},
+        ]
+        mock_run.return_value = _mock_agent_result()
+        mock_sha.return_value = "sha1"
+        mock_verify.return_value = True
+        mock_states.return_value = {"build-and-test-7": "SUCCESS"}
+
+        task_id = _create_ci_task()
+        orch = CIOrchestrator(task_id, config)
+        result = orch.run()
+        assert result["state"] == "COMPLETE"


### PR DESCRIPTION
New 'autopilot fix-ci --pr <N>' command that lists failed CI checks, lets the user select which to fix (interactive or --checks flag), fetches structured failure annotations via the GitHub check-runs API, and loops an agent to fix, push, poll CI until the selected checks pass.

Architecture:
- BaseOrchestrator extracted with shared run(), _run_agent_with_retry(), _do_verify_push(). Existing Orchestrator inherits unchanged behavior.
- New CIOrchestrator: FETCH_ANNOTATIONS, FIX_CI, VERIFY_PUSH, WAIT_CI.
- Uses /check-runs/{id}/annotations API (compact, structured) instead of raw logs (huge, slow on large repos).
- Deduplicates annotations across checks by (path, start_line).
- Strips ANSI escape codes and filters generic noise.
- Excludes *-results aggregation gate checks automatically.

New functions:
- github_api: get_failed_checks, get_check_annotations, get_check_states
- prompts: fix_ci_prompt, format_ci_annotations_for_prompt
- persistence: task_mode + ci_check_names columns (schema v3 migration)
- config: ci_check_names, ci_poll_interval_seconds, ci_poll_timeout_seconds
- cli: fix-ci subcommand, _run dispatches by task_mode
