### PR TITLE
Session lifecycle and robustness

### DIFF
--- a/src/autopilot_loop/cli.py
+++ b/src/autopilot_loop/cli.py
@@ -38,6 +38,24 @@ def _generate_task_id():
     return uuid.uuid4().hex[:8]
 
 
+def _detect_autopilot_branch():
+    """If the current git branch matches autopilot/*, return the branch name.
+
+    Returns None if not on an autopilot branch or git is unavailable.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True, text=True, check=True,
+        )
+        branch = result.stdout.strip()
+        if branch.startswith("autopilot/"):
+            return branch
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
+    return None
+
+
 def cmd_start(args):
     """Start a new autopilot task."""
     config = load_config({
@@ -57,7 +75,14 @@ def cmd_start(args):
         sys.exit(1)
 
     task_id = _generate_task_id()
-    branch = config["branch_pattern"].format(task_id=task_id)
+
+    # Detect if we're already on an autopilot branch
+    existing_branch = _detect_autopilot_branch()
+    if existing_branch:
+        branch = existing_branch
+        logger.info("Detected existing autopilot branch: %s", branch)
+    else:
+        branch = config["branch_pattern"].format(task_id=task_id)
 
     create_task(
         task_id=task_id,
@@ -70,6 +95,9 @@ def cmd_start(args):
 
     from autopilot_loop.persistence import update_task
     update_task(task_id, branch=branch)
+
+    if existing_branch:
+        update_task(task_id, existing_branch=1)
 
     if args.dry_run:
         print("DRY RUN — would start task %s" % task_id)
@@ -392,12 +420,74 @@ def cmd_stop(args):
     except (subprocess.CalledProcessError, FileNotFoundError):
         print("No tmux session found for task %s" % task_id)
 
-    # Update task state
+    # Update task state — save the current state before marking STOPPED
     task = get_task(task_id)
-    if task and task["state"] not in ("COMPLETE", "FAILED"):
+    if task and task["state"] not in ("COMPLETE", "FAILED", "STOPPED"):
         from autopilot_loop.persistence import update_task
-        update_task(task_id, state="FAILED")
-        print("✓ Task %s marked as FAILED" % task_id)
+        update_task(task_id, pre_stop_state=task["state"], state="STOPPED")
+        print("✓ Task %s marked as STOPPED" % task_id)
+
+
+def cmd_restart(args):
+    """Restart a stopped task from its current phase."""
+    task_id = args.task_id
+    task = get_task(task_id)
+
+    if not task:
+        print("Error: task %s not found" % task_id, file=sys.stderr)
+        sys.exit(1)
+
+    if task["state"] != "STOPPED":
+        print("Error: task %s is in state %s, only STOPPED tasks can be restarted" % (task_id, task["state"]),
+              file=sys.stderr)
+        sys.exit(1)
+
+    config = load_config({"model": task["model"]})
+
+    # Determine the phase to restart from. For states that are mid-action
+    # (e.g. FIX, IMPLEMENT), restart from the beginning of that phase.
+    # For waiting states, restart from the state that triggered the wait.
+    restart_state = task["state"]
+    stopped_state = task.get("pre_stop_state") or "INIT"
+
+    # Map waiting/verification states back to their action states
+    _RESTART_STATE_MAP = {
+        "VERIFY_PUSH": "FIX" if task.get("task_mode") != "ci" else "FIX_CI",
+        "WAIT_REVIEW": "REQUEST_REVIEW",
+        "WAIT_CI": "FIX_CI",
+        "VERIFY_PR": "IMPLEMENT",
+    }
+    restart_state = _RESTART_STATE_MAP.get(stopped_state, stopped_state)
+
+    from autopilot_loop.persistence import update_task
+    update_task(task_id, state=restart_state)
+
+    # Launch in tmux
+    sessions_dir = get_sessions_dir(task_id)
+    log_file = os.path.join(sessions_dir, "orchestrator.log")
+    tmux_session = "autopilot-%s" % task_id
+    run_cmd = "autopilot _run --task-id %s 2>&1 | tee -a %s" % (task_id, log_file)
+
+    try:
+        subprocess.run(
+            ["tmux", "new-session", "-d", "-s", tmux_session, run_cmd],
+            check=True,
+        )
+    except FileNotFoundError:
+        logger.warning("tmux not found, running in foreground")
+        cmd_run(argparse.Namespace(task_id=task_id))
+        return
+    except subprocess.CalledProcessError as e:
+        print("Error: failed to create tmux session: %s" % e, file=sys.stderr)
+        sys.exit(1)
+
+    print("✓ Restarting task %s from state %s" % (task_id, restart_state))
+    print("✓ Running in tmux session: %s" % tmux_session)
+    print()
+    print("  To check progress:  autopilot status")
+    print("  To view logs:       autopilot logs --session %s" % task_id)
+    print("  To attach to tmux:  tmux attach -t %s" % tmux_session)
+    print("  To stop:            autopilot stop %s" % task_id)
 
 
 def main():
@@ -433,6 +523,10 @@ def main():
     p_stop = subparsers.add_parser("stop", help="Stop a running task")
     p_stop.add_argument("task_id", type=str, help="Task ID to stop")
 
+    # restart
+    p_restart = subparsers.add_parser("restart", help="Restart a stopped task")
+    p_restart.add_argument("task_id", type=str, help="Task ID to restart")
+
     # fix-ci
     p_fixci = subparsers.add_parser("fix-ci", help="Fix CI failures on an existing PR")
     p_fixci.add_argument("--pr", type=int, required=True, help="PR number")
@@ -457,6 +551,8 @@ def main():
         cmd_logs(args)
     elif args.command == "stop":
         cmd_stop(args)
+    elif args.command == "restart":
+        cmd_restart(args)
     elif args.command == "fix-ci":
         cmd_fix_ci(args)
     elif args.command == "_run":

--- a/src/autopilot_loop/codespace.py
+++ b/src/autopilot_loop/codespace.py
@@ -1,5 +1,6 @@
 """Codespace idle timeout management via gh api."""
 
+import json
 import logging
 import os
 import subprocess
@@ -7,16 +8,43 @@ import subprocess
 logger = logging.getLogger(__name__)
 
 
+def get_idle_timeout():
+    """Get the current idle timeout for the codespace, or None if not in a codespace."""
+    codespace_name = os.environ.get("CODESPACE_NAME")
+    if not codespace_name:
+        return None
+
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api",
+                "/user/codespaces/%s" % codespace_name,
+                "--jq", ".idle_timeout_minutes",
+            ],
+            capture_output=True, text=True, check=True,
+        )
+        return int(result.stdout.strip())
+    except (FileNotFoundError, subprocess.CalledProcessError, ValueError):
+        return None
+
+
 def set_idle_timeout(minutes=120):
     """Set the idle timeout for the current codespace.
 
     Uses: gh api -X PATCH "/user/codespaces/$CODESPACE_NAME" -F idle_timeout_minutes=<value>
 
+    Skips the update if the current timeout is already >= the desired value.
     Non-fatal — logs a warning if it fails (e.g., not in a codespace).
     """
     codespace_name = os.environ.get("CODESPACE_NAME")
     if not codespace_name:
         logger.debug("Not in a codespace (CODESPACE_NAME not set), skipping idle timeout")
+        return
+
+    # Check current timeout before updating
+    current = get_idle_timeout()
+    if current is not None and current >= minutes:
+        logger.info("Codespace idle timeout already set to %dm (>= %dm), skipping", current, minutes)
         return
 
     try:

--- a/src/autopilot_loop/orchestrator.py
+++ b/src/autopilot_loop/orchestrator.py
@@ -41,6 +41,7 @@ from autopilot_loop.prompts import (
     fix_prompt,
     format_ci_annotations_for_prompt,
     format_review_for_prompt,
+    implement_on_existing_branch_prompt,
     implement_prompt,
     plan_and_implement_prompt,
 )
@@ -63,7 +64,11 @@ STATES = [
     "RESOLVE_COMMENTS",
     "COMPLETE",
     "FAILED",
+    "STOPPED",
 ]
+
+# Terminal states — the orchestrator stops when reaching any of these
+TERMINAL_STATES = frozenset({"COMPLETE", "FAILED", "STOPPED"})
 
 
 class BaseOrchestrator:
@@ -81,11 +86,11 @@ class BaseOrchestrator:
         raise NotImplementedError
 
     def run(self):
-        """Run the state machine until COMPLETE or FAILED."""
+        """Run the state machine until a terminal state (COMPLETE, FAILED, or STOPPED)."""
         state = self.task["state"]
         logger.info("[%s] Starting orchestrator from state: %s", self.task_id, state)
 
-        while state not in ("COMPLETE", "FAILED"):
+        while state not in TERMINAL_STATES:
             logger.info("[%s] %s", self.task_id, state)
             try:
                 state = self._transition(state)
@@ -253,11 +258,20 @@ class Orchestrator(BaseOrchestrator):
     def _do_implement(self):
         """Run copilot agent with implement prompt."""
         branch = self.task["branch"]
-        prompt = implement_prompt(
-            task_description=self.task["prompt"],
-            branch_name=branch,
-            custom_instructions=self.config.get("custom_instructions", ""),
-        )
+
+        # Use existing-branch prompt if the branch already exists remotely
+        if self.task.get("existing_branch"):
+            prompt = implement_on_existing_branch_prompt(
+                task_description=self.task["prompt"],
+                branch_name=branch,
+                custom_instructions=self.config.get("custom_instructions", ""),
+            )
+        else:
+            prompt = implement_prompt(
+                task_description=self.task["prompt"],
+                branch_name=branch,
+                custom_instructions=self.config.get("custom_instructions", ""),
+            )
 
         result = self._run_agent_with_retry("IMPLEMENT", prompt, "implement")
         if result is None:

--- a/src/autopilot_loop/persistence.py
+++ b/src/autopilot_loop/persistence.py
@@ -28,7 +28,7 @@ DB_PATH = os.path.join(DB_DIR, "state.db")
 
 # Bump this when the schema changes. Additive changes (new nullable columns)
 # are handled by _migrate(). Breaking changes trigger a DB recreate.
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_meta (
@@ -50,6 +50,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     last_review_id INTEGER,
     task_mode TEXT NOT NULL DEFAULT 'review',
     ci_check_names TEXT,
+    pre_stop_state TEXT,
+    existing_branch INTEGER NOT NULL DEFAULT 0,
     created_at REAL NOT NULL,
     updated_at REAL NOT NULL
 );
@@ -81,6 +83,8 @@ _MIGRATIONS = [
     (2, "tasks", "last_review_id", "INTEGER"),
     (3, "tasks", "task_mode", "TEXT NOT NULL DEFAULT 'review'"),
     (3, "tasks", "ci_check_names", "TEXT"),
+    (4, "tasks", "pre_stop_state", "TEXT"),
+    (4, "tasks", "existing_branch", "INTEGER NOT NULL DEFAULT 0"),
 ]
 
 
@@ -183,7 +187,7 @@ def get_task(task_id):
 _TASK_COLUMNS = frozenset({
     "prompt", "state", "pr_number", "branch", "iteration",
     "max_iterations", "plan_mode", "dry_run", "model", "last_review_id",
-    "task_mode", "ci_check_names", "updated_at",
+    "task_mode", "ci_check_names", "pre_stop_state", "existing_branch", "updated_at",
 })
 
 

--- a/src/autopilot_loop/prompts.py
+++ b/src/autopilot_loop/prompts.py
@@ -6,6 +6,7 @@ on what to do, including git operations, self-review, and PR creation.
 
 __all__ = [
     "implement_prompt",
+    "implement_on_existing_branch_prompt",
     "plan_and_implement_prompt",
     "fix_prompt",
     "fix_ci_prompt",
@@ -45,6 +46,44 @@ def implement_prompt(task_description, branch_name, custom_instructions=""):
         "   examining the output. If you find any issues (bugs, missing tests, style\n"
         "   problems), fix them, commit with a descriptive message, and push again.\n"
         % (branch_name, branch_name, branch_name)
+    )
+
+    return "\n".join(parts)
+
+
+def implement_on_existing_branch_prompt(task_description, branch_name, custom_instructions=""):
+    """Prompt for the IMPLEMENT phase on an existing branch.
+
+    Used when the user starts a new task on a branch that already exists
+    (e.g. autopilot/<task-id>). The agent should NOT create a new branch
+    and should commit directly on the current branch.
+    """
+    parts = []
+
+    if custom_instructions:
+        parts.append(custom_instructions.strip())
+        parts.append("")
+
+    parts.append("## Task")
+    parts.append(task_description.strip())
+    parts.append("")
+    parts.append("## Instructions")
+    parts.append(
+        "IMPORTANT: You are on the existing branch `%s`. Do NOT create a new branch.\n"
+        "Work directly on this branch.\n\n"
+        "1. Implement the task described above.\n"
+        "2. Run any relevant tests to verify your changes work.\n"
+        "3. Stage and commit your changes with a proper, descriptive commit message\n"
+        "   that explains what was changed and why. Do NOT use generic messages.\n"
+        "4. If a PR already exists for this branch, push your changes. If no PR exists,\n"
+        "   create a draft pull request using `gh pr create --draft`. Use the repo's\n"
+        "   PR template (check `.github/PULL_REQUEST_TEMPLATE.md` or similar) to\n"
+        "   structure the PR body. Write a clear title and fill in the template sections.\n"
+        "5. Push the branch: `git push origin %s`\n"
+        "6. After pushing, review your own changes by running `git diff HEAD~1` and\n"
+        "   examining the output. If you find any issues (bugs, missing tests, style\n"
+        "   problems), fix them, commit with a descriptive message, and push again.\n"
+        % (branch_name, branch_name)
     )
 
     return "\n".join(parts)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -6,7 +6,7 @@ import pytest
 
 from autopilot_loop import persistence
 from autopilot_loop.agent import AgentResult
-from autopilot_loop.orchestrator import CIOrchestrator, Orchestrator
+from autopilot_loop.orchestrator import CIOrchestrator, Orchestrator, TERMINAL_STATES
 
 
 @pytest.fixture(autouse=True)
@@ -550,3 +550,51 @@ class TestCIOrchestratorFullLoop:
         orch = CIOrchestrator(task_id, config)
         result = orch.run()
         assert result["state"] == "COMPLETE"
+
+
+class TestTerminalStates:
+    def test_stopped_is_terminal(self):
+        assert "STOPPED" in TERMINAL_STATES
+
+    def test_failed_is_terminal(self):
+        assert "FAILED" in TERMINAL_STATES
+
+    def test_complete_is_terminal(self):
+        assert "COMPLETE" in TERMINAL_STATES
+
+    def test_stopped_task_does_not_run(self, config):
+        """A task in STOPPED state should be treated as terminal."""
+        task_id = _create_test_task()
+        persistence.update_task(task_id, state="STOPPED")
+        orch = Orchestrator(task_id, config)
+        result = orch.run()
+        assert result["state"] == "STOPPED"
+
+
+class TestExistingBranchImplement:
+    @patch("autopilot_loop.orchestrator.run_agent")
+    def test_existing_branch_uses_correct_prompt(self, mock_run, config):
+        """When existing_branch=1, implement uses the existing-branch prompt."""
+        mock_run.return_value = _mock_agent_result()
+        task_id = _create_test_task()
+        persistence.update_task(task_id, existing_branch=1)
+        orch = Orchestrator(task_id, config)
+        orch.task = persistence.get_task(task_id)
+        assert orch._do_implement() == "VERIFY_PR"
+
+        # Verify the prompt contains the existing-branch instruction
+        call_args = mock_run.call_args
+        prompt = call_args[1]["prompt"] if "prompt" in call_args[1] else call_args[0][0]
+        assert "Do NOT create a new branch" in prompt
+
+    @patch("autopilot_loop.orchestrator.run_agent")
+    def test_new_branch_uses_standard_prompt(self, mock_run, config):
+        """When existing_branch is not set, implement uses the standard prompt."""
+        mock_run.return_value = _mock_agent_result()
+        task_id = _create_test_task()
+        orch = Orchestrator(task_id, config)
+        assert orch._do_implement() == "VERIFY_PR"
+
+        call_args = mock_run.call_args
+        prompt = call_args[1]["prompt"] if "prompt" in call_args[1] else call_args[0][0]
+        assert "Create a new git branch" in prompt or "git checkout -b" in prompt

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -97,6 +97,27 @@ def test_create_task_with_flags():
     assert task["dry_run"] == 1
 
 
+def test_stopped_state_persisted():
+    persistence.create_task("t1", "prompt")
+    persistence.update_task("t1", state="STOPPED", pre_stop_state="FIX")
+    task = persistence.get_task("t1")
+    assert task["state"] == "STOPPED"
+    assert task["pre_stop_state"] == "FIX"
+
+
+def test_existing_branch_persisted():
+    persistence.create_task("t1", "prompt")
+    persistence.update_task("t1", existing_branch=1)
+    task = persistence.get_task("t1")
+    assert task["existing_branch"] == 1
+
+
+def test_existing_branch_defaults_to_zero():
+    persistence.create_task("t1", "prompt")
+    task = persistence.get_task("t1")
+    assert task["existing_branch"] == 0
+
+
 def test_last_review_id_persisted():
     persistence.create_task("t1", "prompt")
     task = persistence.get_task("t1")
@@ -146,6 +167,8 @@ def test_migration_from_pre_versioned_db(tmp_path, monkeypatch):
     assert task["last_review_id"] is None
     assert task["task_mode"] == "review"
     assert task["ci_check_names"] is None
+    assert task["pre_stop_state"] is None
+    assert task["existing_branch"] == 0
 
     # New columns should be usable
     persistence.update_task("old1", task_mode="ci", ci_check_names='["check-a"]')


### PR DESCRIPTION
## Summary

This PR addresses three session lifecycle and robustness issues:

### 1. STOPPED state (Closes #6)
- **Problem**: Stopping an autopilot session marked it as `FAILED`, making it indistinguishable from actual failures.
- **Fix**: Add `STOPPED` as a distinct terminal state. `cmd_stop` now saves the task's current state in `pre_stop_state` before marking it `STOPPED`.
- **New command**: `autopilot restart <task_id>` re-launches a stopped task from its pre-stop phase, mapping waiting/verification states back to their action states.

### 2. Existing autopilot branch detection (Closes #7)
- **Problem**: Running `autopilot start --prompt "..."` on an existing `autopilot/<task-id>` branch created an entirely new branch instead of working on the current one.
- **Fix**: `cmd_start` now checks the current git branch. If it matches `autopilot/*`, it reuses that branch and uses a tailored prompt (`implement_on_existing_branch_prompt`) that instructs the agent to stay on the current branch rather than creating a new one.

### 3. Check codespace idle timeout before setting (Closes #4)
- **Problem**: `set_idle_timeout()` always issued a PATCH request, even when the codespace timeout was already >= the desired value.
- **Fix**: Add `get_idle_timeout()` to read the current value first. Skip the PATCH if the timeout is already sufficient.

### Schema Changes
- Schema version bumped from 3 to 4
- New columns: `pre_stop_state TEXT`, `existing_branch INTEGER NOT NULL DEFAULT 0`
- Migration handles existing databases gracefully

### Tests
- 93 tests passing (7 new tests for STOPPED state, existing branch, and migration)
