### PR TITLE
Unify CLI UX and add PR description updates in fix loop

### DIFF
--- a/src/autopilot_loop/cli.py
+++ b/src/autopilot_loop/cli.py
@@ -56,6 +56,49 @@ def _detect_autopilot_branch():
     return None
 
 
+def _launch_in_tmux(task_id, mode="review", branch=None, pr_number=None):
+    """Launch a task in tmux with standardized output.
+
+    Args:
+        task_id: The task ID to launch.
+        mode: Display mode ("review", "ci", "resume").
+        branch: Branch name for display.
+        pr_number: PR number for display (optional).
+    """
+    sessions_dir = get_sessions_dir(task_id)
+    log_file = os.path.join(sessions_dir, "orchestrator.log")
+    tmux_session = "autopilot-%s" % task_id
+    run_cmd = "autopilot _run --task-id %s 2>&1 | tee -a %s" % (task_id, log_file)
+
+    try:
+        subprocess.run(
+            ["tmux", "new-session", "-d", "-s", tmux_session, run_cmd],
+            check=True,
+        )
+    except FileNotFoundError:
+        logger.warning("tmux not found, running in foreground")
+        cmd_run(argparse.Namespace(task_id=task_id))
+        return
+    except subprocess.CalledProcessError as e:
+        print("Error: failed to create tmux session: %s" % e, file=sys.stderr)
+        sys.exit(1)
+
+    # Standardized output
+    print("\u2713 Autopilot session started")
+    print("  Task:     %s" % task_id)
+    print("  Mode:     %s" % mode)
+    if branch:
+        print("  Branch:   %s" % branch)
+    if pr_number:
+        print("  PR:       #%d" % pr_number)
+    print("  tmux:     %s" % tmux_session)
+    print()
+    print("  autopilot status              — check progress")
+    print("  autopilot logs --session %s  — view logs" % task_id)
+    print("  tmux attach -t %s     — attach to session" % tmux_session)
+    print("  autopilot stop %s            — stop task" % task_id)
+
+
 def cmd_start(args):
     """Start a new autopilot task."""
     config = load_config({
@@ -202,25 +245,7 @@ def cmd_resume(args):
     from autopilot_loop.persistence import update_task
     update_task(task_id, pr_number=args.pr, state="PARSE_REVIEW", branch=branch)
 
-    # Launch in tmux
-    sessions_dir = get_sessions_dir(task_id)
-    log_file = os.path.join(sessions_dir, "orchestrator.log")
-    tmux_session = "autopilot-%s" % task_id
-    run_cmd = "autopilot _run --task-id %s 2>&1 | tee -a %s" % (task_id, log_file)
-
-    try:
-        subprocess.run(
-            ["tmux", "new-session", "-d", "-s", tmux_session, run_cmd],
-            check=True,
-        )
-    except FileNotFoundError:
-        logger.warning("tmux not found, running in foreground")
-        cmd_run(argparse.Namespace(task_id=task_id))
-        return
-
-    print("✓ Resuming PR #%d as task %s" % (args.pr, task_id))
-    print("✓ Branch: %s" % branch)
-    print("✓ Running in tmux session: %s" % tmux_session)
+    _launch_in_tmux(task_id, mode="resume", branch=branch, pr_number=args.pr)
 
 
 def cmd_status(args):
@@ -384,25 +409,7 @@ def cmd_fix_ci(args):
         ci_check_names=json.dumps(check_names),
     )
 
-    # Launch in tmux
-    sessions_dir = get_sessions_dir(task_id)
-    log_file = os.path.join(sessions_dir, "orchestrator.log")
-    tmux_session = "autopilot-%s" % task_id
-    run_cmd = "autopilot _run --task-id %s 2>&1 | tee -a %s" % (task_id, log_file)
-
-    try:
-        subprocess.run(
-            ["tmux", "new-session", "-d", "-s", tmux_session, run_cmd],
-            check=True,
-        )
-    except FileNotFoundError:
-        logger.warning("tmux not found, running in foreground")
-        cmd_run(argparse.Namespace(task_id=task_id))
-        return
-
-    print("\u2713 Fixing CI on PR #%d as task %s" % (args.pr, task_id))
-    print("\u2713 Branch: %s" % branch)
-    print("\u2713 Running in tmux session: %s" % tmux_session)
+    _launch_in_tmux(task_id, mode="ci", branch=branch, pr_number=args.pr)
 
 
 def cmd_stop(args):
@@ -462,32 +469,9 @@ def cmd_restart(args):
     from autopilot_loop.persistence import update_task
     update_task(task_id, state=restart_state)
 
-    # Launch in tmux
-    sessions_dir = get_sessions_dir(task_id)
-    log_file = os.path.join(sessions_dir, "orchestrator.log")
-    tmux_session = "autopilot-%s" % task_id
-    run_cmd = "autopilot _run --task-id %s 2>&1 | tee -a %s" % (task_id, log_file)
-
-    try:
-        subprocess.run(
-            ["tmux", "new-session", "-d", "-s", tmux_session, run_cmd],
-            check=True,
-        )
-    except FileNotFoundError:
-        logger.warning("tmux not found, running in foreground")
-        cmd_run(argparse.Namespace(task_id=task_id))
-        return
-    except subprocess.CalledProcessError as e:
-        print("Error: failed to create tmux session: %s" % e, file=sys.stderr)
-        sys.exit(1)
-
-    print("✓ Restarting task %s from state %s" % (task_id, restart_state))
-    print("✓ Running in tmux session: %s" % tmux_session)
-    print()
-    print("  To check progress:  autopilot status")
-    print("  To view logs:       autopilot logs --session %s" % task_id)
-    print("  To attach to tmux:  tmux attach -t %s" % tmux_session)
-    print("  To stop:            autopilot stop %s" % task_id)
+    mode = "ci" if task.get("task_mode") == "ci" else "review"
+    _launch_in_tmux(task_id, mode="restart (%s)" % mode, branch=task.get("branch"),
+                    pr_number=task.get("pr_number"))
 
 
 def main():

--- a/src/autopilot_loop/prompts.py
+++ b/src/autopilot_loop/prompts.py
@@ -173,6 +173,11 @@ def fix_prompt(review_comments_text, custom_instructions=""):
         "   The comment_id values are provided in the comments above (as `[comment_id: N]`).\n"
         "   Status must be either `fixed` or `skipped`.\n"
         "   Do NOT commit this file — just write it to disk.\n"
+        "8. If your fixes significantly changed the implementation approach or\n"
+        "   the PR scope has evolved, update the PR title and/or description\n"
+        "   using `gh pr edit --title '...' --body '...'` to reflect the\n"
+        "   current state of the changes. Only do this if the approach actually\n"
+        "   changed — minor fixes don't need a description update.\n"
     )
 
     return "\n".join(parts)


### PR DESCRIPTION
## Summary

This PR unifies the CLI user experience and adds agent-driven PR description updates.

### 1. Unified post-start experience (Closes #5)
- **Problem**: `autopilot start` and `autopilot fix-ci` had different output formats after launching a session.
- **Fix**: Extract `_launch_in_tmux()` shared helper that all commands (`start`, `fix-ci`, `resume`, `restart`) use. Every launch now prints a standardized summary:
  ```
  ✓ Autopilot session started
    Task:     a1b2c3d4
    Mode:     review
    Branch:   autopilot/a1b2c3d4
    tmux:     autopilot-a1b2c3d4

    autopilot status              — check progress
    autopilot logs --session ...  — view logs
    tmux attach -t ...            — attach to session
    autopilot stop ...            — stop task
  ```
- Removes ~60 lines of duplicated tmux launch + output code from 4 command handlers.

### 2. Update PR description throughout the loop (Closes #2)
- **Problem**: PR description was only generated during the initial IMPLEMENT phase and never updated during fix iterations, even when the approach changed.
- **Fix**: Agent-driven approach — `fix_prompt()` now includes step 8 instructing the agent to update the PR title/description via `gh pr edit` if the implementation approach changed significantly during fixes.
- This keeps the orchestrator simple (no new state or API calls needed). The agent uses its judgment to decide when an update is warranted.

### Tests
- 93 tests passing (no regressions)
