### PR TITLE
Interactive TUI dashboard, tmux scrollback, session exit summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ autopilot restart abc123                  # Restart a stopped task
 
 # Monitoring
 autopilot status                          # Show all task statuses (rich table)
-autopilot status --watch                  # Auto-refreshing live dashboard
+autopilot status --watch                  # Interactive dashboard with keybindings
 autopilot status --json                   # JSON output for scripting
 autopilot logs                            # Show latest task log
 autopilot logs --session abc123           # Show specific task log
@@ -64,6 +64,30 @@ autopilot logs --session abc123 --phase fix-1  # Show specific phase
 autopilot attach abc123                   # Attach to a task's tmux session
 autopilot next                            # Jump to next session needing attention
 ```
+
+### Interactive Dashboard (`--watch`)
+
+Full-screen TUI with animated spinners for active sessions:
+
+```
+╭─ autopilot-loop — Sessions ──────────────────────────────────────────────────╮
+│  #  Task ID   Mode    Branch                 State            PR   Iter  Age │
+│► 1  a1b2c3d4  review  autopilot/a1b2c3d4    ⠹ IMPLEMENT      -    0/5  < 1m │
+│  2  e5f6g7h8  ci      autopilot/e5f6g7h8    ◐ WAIT_CI        #43  1/5   3m  │
+│  3  i9j0k1l2  review  autopilot/i9j0k1l2    ■ STOPPED        #44  3/5  45m  │
+│  4  m3n4o5p6  review  autopilot/m3n4o5p6    ✓ COMPLETE       #45  2/5   1h  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+ j/k navigate  Enter attach  x stop  r refresh  q quit
+```
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Move selection down |
+| `k` / `↑` | Move selection up |
+| `Enter` | Attach to selected tmux session |
+| `x` | Stop selected session |
+| `r` | Force refresh |
+| `q` / `Esc` | Quit |
 
 ## Configuration
 

--- a/src/autopilot_loop/cli.py
+++ b/src/autopilot_loop/cli.py
@@ -69,12 +69,29 @@ def _launch_in_tmux(task_id, mode="review", branch=None, pr_number=None):
     sessions_dir = get_sessions_dir(task_id)
     log_file = os.path.join(sessions_dir, "orchestrator.log")
     tmux_session = "autopilot-%s" % task_id
-    run_cmd = "autopilot _run --task-id %s 2>&1 | tee -a %s" % (task_id, log_file)
+
+    # Run orchestrator, then print summary and keep pane alive (#15)
+    run_cmd = (
+        "autopilot _run --task-id %s 2>&1 | tee -a %s; "
+        "echo ''; echo '=== Task %s finished ==='; "
+        "echo 'Run: autopilot status  or  autopilot logs --session %s'; "
+        "echo 'Press Enter to close this pane.'; read _dummy"
+        % (task_id, log_file, task_id, task_id)
+    )
 
     try:
         subprocess.run(
             ["tmux", "new-session", "-d", "-s", tmux_session, run_cmd],
             check=True,
+        )
+        # Enable mouse scrolling and increase scrollback buffer (#14)
+        subprocess.run(
+            ["tmux", "set-option", "-t", tmux_session, "mouse", "on"],
+            check=False, capture_output=True,
+        )
+        subprocess.run(
+            ["tmux", "set-option", "-t", tmux_session, "history-limit", "50000"],
+            check=False, capture_output=True,
         )
     except FileNotFoundError:
         logger.warning("tmux not found, running in foreground")
@@ -232,14 +249,23 @@ def cmd_resume(args):
 
 def cmd_status(args):
     """Show status of all autopilot tasks."""
-    from autopilot_loop.dashboard import status_json, status_table, status_watch
+    from autopilot_loop.dashboard import (
+        status_interactive,
+        status_json,
+        status_table,
+        status_watch,
+    )
 
     if getattr(args, "json", False):
         status_json()
         return
 
     if getattr(args, "watch", False):
-        status_watch(interval=getattr(args, "interval", 5))
+        interval = getattr(args, "interval", 2)
+        if sys.stdout.isatty():
+            status_interactive(interval=interval)
+        else:
+            status_watch(interval=interval)
         return
 
     status_table()

--- a/src/autopilot_loop/dashboard.py
+++ b/src/autopilot_loop/dashboard.py
@@ -1,68 +1,129 @@
 """Status dashboard rendering for autopilot-loop.
 
-Provides table, JSON, and live-watch views of task status.
-Uses the `rich` library for formatted terminal output.
+Provides table, JSON, live-watch, and interactive TUI views of task status.
+Uses the ``rich`` library for formatted terminal output.
+Interactive mode uses ``termios`` for raw keyboard input (Unix only).
 """
 
 import json
+import os
+import select
+import subprocess
+import sys
 import time
 
-from autopilot_loop.persistence import get_active_tasks, list_tasks
+from autopilot_loop.persistence import get_active_tasks, list_tasks, update_task
 
 __all__ = [
     "status_table",
     "status_json",
     "status_watch",
+    "status_interactive",
 ]
 
+
+# ---------------------------------------------------------------------------
+# Elapsed time formatting
+# ---------------------------------------------------------------------------
 
 def _format_elapsed(created_at):
     elapsed = time.time() - created_at
     if elapsed < 60:
         return "< 1m"
     elif elapsed < 3600:
-        return "%dm ago" % (elapsed / 60)
+        return "%dm" % (elapsed / 60)
     else:
-        return "%.1fh ago" % (elapsed / 3600)
+        return "%.1fh" % (elapsed / 3600)
 
+
+# ---------------------------------------------------------------------------
+# Animated spinners & color palette
+# ---------------------------------------------------------------------------
+
+_WORKING_FRAMES = list("\u280b\u2819\u2839\u2838\u283c\u2834\u2826\u2827\u2807\u280f")
+_WAITING_FRAMES = list("\u25d0\u25d3\u25d1\u25d2")
 
 _STATE_STYLES = {
-    "COMPLETE": "green",
-    "FAILED": "red",
+    "COMPLETE": "dim green",
+    "FAILED": "bright_red",
     "STOPPED": "yellow",
-    "WAIT_REVIEW": "cyan",
-    "WAIT_CI": "cyan",
-    "IMPLEMENT": "blue",
-    "PLAN_AND_IMPLEMENT": "blue",
-    "FIX": "magenta",
-    "FIX_CI": "magenta",
+    "WAIT_REVIEW": "bright_cyan",
+    "WAIT_CI": "bright_cyan",
+    "IMPLEMENT": "bright_green",
+    "PLAN_AND_IMPLEMENT": "bright_green",
+    "FIX": "bright_green",
+    "FIX_CI": "bright_green",
+    "INIT": "bright_white",
+    "REQUEST_REVIEW": "bright_cyan",
+    "PARSE_REVIEW": "bright_cyan",
+    "VERIFY_PR": "bright_green",
+    "VERIFY_PUSH": "bright_green",
+    "RESOLVE_COMMENTS": "bright_green",
+    "FETCH_ANNOTATIONS": "bright_cyan",
 }
 
-_STATE_INDICATORS = {
+_WORKING_STATES = frozenset({
+    "IMPLEMENT", "PLAN_AND_IMPLEMENT", "FIX", "FIX_CI",
+    "VERIFY_PR", "VERIFY_PUSH", "RESOLVE_COMMENTS", "INIT",
+})
+
+_WAITING_STATES = frozenset({
+    "WAIT_REVIEW", "WAIT_CI", "REQUEST_REVIEW",
+    "PARSE_REVIEW", "FETCH_ANNOTATIONS",
+})
+
+_STATIC_INDICATORS = {
     "COMPLETE": "\u2713",
     "FAILED": "\u2717",
     "STOPPED": "\u25a0",
 }
 
 
-def _build_table(title, tasks):
-    """Build a rich Table from a list of task dicts."""
+def _get_indicator(state, tick):
+    """Return an animated or static indicator for the given state."""
+    if state in _WORKING_STATES:
+        return _WORKING_FRAMES[tick % len(_WORKING_FRAMES)]
+    if state in _WAITING_STATES:
+        return _WAITING_FRAMES[tick % len(_WAITING_FRAMES)]
+    return _STATIC_INDICATORS.get(state, "\u25cf")
+
+
+# ---------------------------------------------------------------------------
+# Table builder
+# ---------------------------------------------------------------------------
+
+def _build_table(title, tasks, selected_idx=-1, tick=0):
+    """Build a rich Table from a list of task dicts.
+
+    Args:
+        title: Table title string.
+        tasks: List of task dicts from persistence.
+        selected_idx: Index of the highlighted row (-1 for none).
+        tick: Animation tick counter for spinner frames.
+    """
+    from rich.box import ROUNDED
     from rich.table import Table
 
-    table = Table(title=title, border_style="dim")
-    table.add_column("#", style="dim", width=3)
-    table.add_column("Task ID", style="bold")
-    table.add_column("Mode")
-    table.add_column("Branch")
-    table.add_column("State")
-    table.add_column("PR")
-    table.add_column("Iter")
-    table.add_column("Elapsed", justify="right")
+    table = Table(
+        title="[bold bright_white]%s[/]" % title,
+        box=ROUNDED,
+        border_style="dim cyan",
+        expand=True,
+        padding=(0, 1),
+    )
+    table.add_column("#", style="dim", width=3, no_wrap=True)
+    table.add_column("Task ID", style="bold", no_wrap=True)
+    table.add_column("Mode", no_wrap=True)
+    table.add_column("Branch", no_wrap=True)
+    table.add_column("State", no_wrap=True)
+    table.add_column("PR", no_wrap=True)
+    table.add_column("Iter", no_wrap=True)
+    table.add_column("Elapsed", justify="right", no_wrap=True)
 
-    for i, t in enumerate(tasks, 1):
+    for i, t in enumerate(tasks):
         state = t["state"]
         style = _STATE_STYLES.get(state, "")
-        indicator = _STATE_INDICATORS.get(state, "\u25cf")
+        indicator = _get_indicator(state, tick)
         state_display = "%s %s" % (indicator, state)
         pr = "#%d" % t["pr_number"] if t["pr_number"] else "-"
         iteration = "%d/%d" % (t["iteration"], t["max_iterations"])
@@ -72,17 +133,47 @@ def _build_table(title, tasks):
             branch = branch[:27] + "..."
         elapsed = _format_elapsed(t["created_at"])
 
+        is_selected = (i == selected_idx)
+        prefix = "\u25ba " if is_selected else "  "
+        row_style = "reverse" if is_selected else ""
+
+        state_cell = "[%s]%s[/]" % (style, state_display) if style else state_display
+
         table.add_row(
-            str(i), t["id"], mode, branch,
-            "[%s]%s[/]" % (style, state_display) if style else state_display,
-            pr, iteration, elapsed,
+            prefix + str(i + 1), t["id"], mode, branch,
+            state_cell, pr, iteration, elapsed,
+            style=row_style,
         )
 
     return table
 
 
+def _build_footer():
+    """Build the keybinding hint footer."""
+    from rich.text import Text
+
+    footer = Text()
+    keys = [
+        ("j/k", "navigate"),
+        ("Enter", "attach"),
+        ("x", "stop"),
+        ("r", "refresh"),
+        ("q", "quit"),
+    ]
+    for i, (key, action) in enumerate(keys):
+        if i > 0:
+            footer.append("  ", style="dim")
+        footer.append(key, style="bold bright_white")
+        footer.append(" %s" % action, style="dim")
+    return footer
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive views
+# ---------------------------------------------------------------------------
+
 def status_table():
-    """Print a rich table of all tasks."""
+    """Print a rich table of all tasks (non-interactive)."""
     from rich.console import Console
 
     tasks = list_tasks()
@@ -96,7 +187,7 @@ def status_table():
 
     active = get_active_tasks()
     if active:
-        console.print("\\n[dim]%d active session(s)[/dim]" % len(active))
+        console.print("\n[dim]%d active session(s)[/dim]" % len(active))
 
 
 def status_json():
@@ -118,7 +209,7 @@ def status_json():
 
 
 def status_watch(interval=5):
-    """Auto-refreshing status display."""
+    """Auto-refreshing status display (non-interactive, for piped output)."""
     from rich.console import Console
     from rich.live import Live
 
@@ -141,3 +232,153 @@ def status_watch(interval=5):
                 live.update(build())
     except KeyboardInterrupt:
         pass
+
+
+# ---------------------------------------------------------------------------
+# Keyboard input (raw terminal mode)
+# ---------------------------------------------------------------------------
+
+def _read_key(fd, timeout=2.0):
+    """Read a single keypress from the terminal.
+
+    Returns a string identifying the key, or None on timeout.
+    """
+    ready, _, _ = select.select([fd], [], [], timeout)
+    if not ready:
+        return None
+
+    ch = os.read(fd, 1)
+    if not ch:
+        return None
+
+    b = ch[0] if isinstance(ch[0], int) else ord(ch[0])
+
+    # Enter
+    if b in (10, 13):
+        return "enter"
+    # Escape — could be bare Esc or start of arrow sequence
+    if b == 27:
+        ready2, _, _ = select.select([fd], [], [], 0.05)
+        if ready2:
+            seq = os.read(fd, 2)
+            if seq == b"[A":
+                return "up"
+            if seq == b"[B":
+                return "down"
+        return "esc"
+    if b == ord("j"):
+        return "down"
+    if b == ord("k"):
+        return "up"
+    if b == ord("q"):
+        return "quit"
+    if b == ord("x"):
+        return "stop"
+    if b == ord("r"):
+        return "refresh"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Interactive TUI
+# ---------------------------------------------------------------------------
+
+def status_interactive(interval=2):
+    """Full-screen interactive dashboard with keybindings.
+
+    Requires a TTY. Falls back to status_watch() if not a terminal.
+    """
+    if not sys.stdin.isatty():
+        status_watch(interval=interval)
+        return
+
+    import termios
+    import tty
+
+    from rich.console import Console, Group
+    from rich.live import Live
+
+    console = Console()
+    selected = 0
+    tick = 0
+
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+
+    def render():
+        tasks = list_tasks()
+        if not tasks:
+            from rich.table import Table
+            table = Table(title="[bold bright_white]autopilot-loop \u2014 No sessions[/]")
+            return Group(table, _build_footer()), tasks
+
+        sel = min(selected, len(tasks) - 1)
+        table = _build_table("autopilot-loop \u2014 Sessions", tasks,
+                             selected_idx=sel, tick=tick)
+        return Group(table, _build_footer()), tasks
+
+    try:
+        tty.setraw(fd)
+        content, tasks = render()
+
+        with Live(content, console=console, screen=True, refresh_per_second=4) as live:
+            while True:
+                key = _read_key(fd, timeout=interval)
+
+                if key in ("quit", "esc"):
+                    break
+
+                if key == "down":
+                    tasks = list_tasks()
+                    if tasks:
+                        selected = min(selected + 1, len(tasks) - 1)
+
+                elif key == "up":
+                    tasks = list_tasks()
+                    if tasks:
+                        selected = max(selected - 1, 0)
+
+                elif key == "enter":
+                    tasks = list_tasks()
+                    if tasks and 0 <= selected < len(tasks):
+                        task = tasks[selected]
+                        tmux_session = "autopilot-%s" % task["id"]
+                        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+                        try:
+                            subprocess.run(
+                                ["tmux", "switch-client", "-t", tmux_session],
+                                check=True,
+                            )
+                        except subprocess.CalledProcessError:
+                            try:
+                                os.execvp("tmux", ["tmux", "attach", "-t", tmux_session])
+                            except FileNotFoundError:
+                                pass
+                        tty.setraw(fd)
+
+                elif key == "stop":
+                    tasks = list_tasks()
+                    if tasks and 0 <= selected < len(tasks):
+                        task = tasks[selected]
+                        if task["state"] not in ("COMPLETE", "FAILED", "STOPPED"):
+                            tmux_session = "autopilot-%s" % task["id"]
+                            try:
+                                subprocess.run(
+                                    ["tmux", "kill-session", "-t", tmux_session],
+                                    check=True, capture_output=True,
+                                )
+                            except (subprocess.CalledProcessError, FileNotFoundError):
+                                pass
+                            update_task(task["id"],
+                                        pre_stop_state=task["state"],
+                                        state="STOPPED")
+
+                tick += 1
+                content, tasks = render()
+                live.update(content)
+
+    except KeyboardInterrupt:
+        pass
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)


### PR DESCRIPTION
## Summary

Demo-ready UX overhaul: interactive TUI dashboard, tmux quality-of-life fixes.

### Interactive TUI Dashboard (Closes #11)

`autopilot status --watch` is now a full-screen interactive dashboard inspired by [gavraz/recon](https://github.com/gavraz/recon):

- **Keybindings**: `j`/`k` to navigate, `Enter` to attach, `x` to stop, `r` to refresh, `q` to quit
- **Animated spinners**: braille spinners (bright green) for working states, quarter-circle spinners (bright cyan) for waiting states
- **Row highlighting**: selected row gets `►` prefix + reverse video
- **Polished colors**: dim cyan rounded borders, bright white title, color-coded states (bright green working, bright cyan waiting, yellow stopped, dim green complete, bright red failed)
- **Footer bar**: always-visible keybinding hints
- **TTY detection**: falls back to passive auto-refresh when piped (non-TTY)
- **No new dependencies**: uses `termios` for keyboard input (Unix standard, no pip install needed)

### tmux Scrollback (Closes #14)

Each new tmux session now has `mouse=on` and `history-limit=50000`. You can scroll up with mouse wheel or trackpad — no more `^[[A` escape sequences.

### Session Exit Summary (Closes #15)

When a task finishes, the tmux pane no longer vanishes with `[exited]`. Instead it prints:

```
=== Task abc12345 finished ===
Run: autopilot status  or  autopilot logs --session abc12345
Press Enter to close this pane.
```

### Tests
- 97 tests passing, ruff clean
