### PR TITLE
TUI polish: alternate screen, safe actions, detail panel, log viewer

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,8 +12,10 @@
 - **Python 3.8+ compatible** — no walrus operator, no `str.removeprefix`, use `% formatting` not f-strings
 - **CLI output uses `_launch_in_tmux()`** — all commands that start tmux sessions go through this shared helper; never duplicate tmux launch logic inline
 - **Dashboard rendering lives in `dashboard.py`** — not in `cli.py`
+- **TUI actions must be safe** — never `os.execvp` or crash out of the TUI; catch all errors and show a status message instead
+- **TUI uses alternate screen buffer** — `_enter_tui()` / `_exit_tui()` in dashboard.py; always restore terminal in a `finally` block
 - **Persistence changes need schema migration** — bump `SCHEMA_VERSION`, add to `_MIGRATIONS` list, add column to `SCHEMA`, add to `_TASK_COLUMNS` frozenset
-- **Terminal states are `COMPLETE`, `FAILED`, `STOPPED`** — use `TERMINAL_STATES` from orchestrator, not hardcoded tuples
+- **Terminal states are `COMPLETE`, `FAILED`, `STOPPED`** — use `TERMINAL_STATES` from orchestrator or `_TERMINAL_STATES` from dashboard, not hardcoded tuples
 - **Branch locking** — `get_tasks_on_branch()` prevents concurrent tasks on the same branch
 
 ## When Adding a New CLI Command

--- a/README.md
+++ b/README.md
@@ -67,18 +67,24 @@ autopilot next                            # Jump to next session needing attenti
 
 ### Interactive Dashboard (`--watch`)
 
-Full-screen TUI with animated spinners for active sessions:
+Full-screen TUI with animated spinners, detail panel, and built-in log viewer:
 
 ```
-╭─ autopilot-loop — Sessions ──────────────────────────────────────────────────╮
-│  #  Task ID   Mode    Branch                 State            PR   Iter  Age │
-│► 1  a1b2c3d4  review  autopilot/a1b2c3d4    ⠹ IMPLEMENT      -    0/5  < 1m │
-│  2  e5f6g7h8  ci      autopilot/e5f6g7h8    ◐ WAIT_CI        #43  1/5   3m  │
-│  3  i9j0k1l2  review  autopilot/i9j0k1l2    ■ STOPPED        #44  3/5  45m  │
-│  4  m3n4o5p6  review  autopilot/m3n4o5p6    ✓ COMPLETE       #45  2/5   1h  │
-╰──────────────────────────────────────────────────────────────────────────────╯
- j/k navigate  Enter attach  x stop  r refresh  q quit
+┏━ autopilot-loop — Sessions (3) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                              ┃
+┃   #   Task ID    Mode     Branch                  State          PR    Iter   ┃
+┃                                                                              ┃
+┃   ► 1  a1b2c3d4  review   autopilot/a1b2c3d4     ⠹ IMPLEMENT    -     0/5   ┃
+┃                                                                              ┃
+┃     2  e5f6g7h8  ci       autopilot/e5f6g7h8     ◐ WAIT_CI      #43   1/5   ┃
+┃                                                                              ┃
+┃     3  i9j0k1l2  review   autopilot/i9j0k1l2     ■ STOPPED      #44   3/5   ┃
+┃                                                                              ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+ j/k navigate  Enter attach  x stop  l logs  d detail  r refresh  q quit
 ```
+
+**Session list keybindings:**
 
 | Key | Action |
 |-----|--------|
@@ -86,8 +92,22 @@ Full-screen TUI with animated spinners for active sessions:
 | `k` / `↑` | Move selection up |
 | `Enter` | Attach to selected tmux session |
 | `x` | Stop selected session |
+| `l` | Open log viewer for selected task |
+| `d` / `Space` | Toggle detail panel (task info + log tail) |
 | `r` | Force refresh |
-| `q` / `Esc` | Quit |
+| `q` / `Esc` | Quit (or close panel) |
+
+**Log viewer keybindings** (inside `l`):
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Scroll down |
+| `k` / `↑` | Scroll up |
+| `G` | Jump to end |
+| `g` | Jump to top |
+| `q` / `Esc` | Back to session list |
+
+All actions are safe — errors show a status message instead of crashing. The dashboard runs in an alternate screen buffer (no scrollback bleed).
 
 ## Configuration
 

--- a/src/autopilot_loop/dashboard.py
+++ b/src/autopilot_loop/dashboard.py
@@ -3,6 +3,12 @@
 Provides table, JSON, live-watch, and interactive TUI views of task status.
 Uses the ``rich`` library for formatted terminal output.
 Interactive mode uses ``termios`` for raw keyboard input (Unix only).
+
+Views:
+- status_table(): one-shot table print
+- status_json(): JSON output for scripting
+- status_watch(): passive auto-refresh (non-interactive, for piped output)
+- status_interactive(): full-screen TUI with keybindings, detail panel, log viewer
 """
 
 import json
@@ -12,7 +18,12 @@ import subprocess
 import sys
 import time
 
-from autopilot_loop.persistence import get_active_tasks, list_tasks, update_task
+from autopilot_loop.persistence import (
+    get_active_tasks,
+    get_sessions_dir,
+    list_tasks,
+    update_task,
+)
 
 __all__ = [
     "status_table",
@@ -78,6 +89,8 @@ _STATIC_INDICATORS = {
     "STOPPED": "\u25a0",
 }
 
+_TERMINAL_STATES = frozenset({"COMPLETE", "FAILED", "STOPPED"})
+
 
 def _get_indicator(state, tick):
     """Return an animated or static indicator for the given state."""
@@ -92,7 +105,7 @@ def _get_indicator(state, tick):
 # Table builder
 # ---------------------------------------------------------------------------
 
-def _build_table(title, tasks, selected_idx=-1, tick=0):
+def _build_table(title, tasks, selected_idx=-1, tick=0, compact=False):
     """Build a rich Table from a list of task dicts.
 
     Args:
@@ -100,18 +113,20 @@ def _build_table(title, tasks, selected_idx=-1, tick=0):
         tasks: List of task dicts from persistence.
         selected_idx: Index of the highlighted row (-1 for none).
         tick: Animation tick counter for spinner frames.
+        compact: If True, use minimal padding (for detail panel mode).
     """
-    from rich.box import ROUNDED
+    from rich.box import HEAVY
     from rich.table import Table
 
+    pad = (0, 1) if compact else (1, 1)
     table = Table(
         title="[bold bright_white]%s[/]" % title,
-        box=ROUNDED,
+        box=HEAVY,
         border_style="dim cyan",
         expand=True,
-        padding=(0, 1),
+        padding=pad,
     )
-    table.add_column("#", style="dim", width=3, no_wrap=True)
+    table.add_column("#", style="dim", width=4, no_wrap=True)
     table.add_column("Task ID", style="bold", no_wrap=True)
     table.add_column("Mode", no_wrap=True)
     table.add_column("Branch", no_wrap=True)
@@ -134,7 +149,7 @@ def _build_table(title, tasks, selected_idx=-1, tick=0):
         elapsed = _format_elapsed(t["created_at"])
 
         is_selected = (i == selected_idx)
-        prefix = "\u25ba " if is_selected else "  "
+        prefix = " \u25ba " if is_selected else "   "
         row_style = "reverse" if is_selected else ""
 
         state_cell = "[%s]%s[/]" % (style, state_display) if style else state_display
@@ -148,15 +163,97 @@ def _build_table(title, tasks, selected_idx=-1, tick=0):
     return table
 
 
-def _build_footer():
-    """Build the keybinding hint footer."""
+# ---------------------------------------------------------------------------
+# Detail panel builder
+# ---------------------------------------------------------------------------
+
+def _build_detail_panel(task):
+    """Build a detail panel for the selected task."""
+    from rich.box import HEAVY
+    from rich.panel import Panel
     from rich.text import Text
 
+    lines = Text()
+    lines.append("Task ", style="dim")
+    lines.append(task["id"], style="bold bright_white")
+    lines.append(" \u2014 %s\n" % task.get("task_mode", "review"), style="dim")
+
+    lines.append("Branch:  ", style="dim")
+    lines.append("%s\n" % (task.get("branch") or "-"), style="bright_white")
+
+    lines.append("State:   ", style="dim")
+    state = task["state"]
+    style = _STATE_STYLES.get(state, "")
+    lines.append("%s" % state, style=style)
+    lines.append("  (%s)\n" % _format_elapsed(task["created_at"]), style="dim")
+
+    pr_num = task.get("pr_number")
+    lines.append("PR:      ", style="dim")
+    lines.append("%s\n" % ("#%d" % pr_num if pr_num else "not yet created"), style="bright_white")
+
+    lines.append("Iter:    ", style="dim")
+    lines.append("%d/%d\n" % (task["iteration"], task["max_iterations"]), style="bright_white")
+
+    # Tail the orchestrator log
+    lines.append("\n")
+    lines.append("Recent log:\n", style="bold dim")
+    log_lines = _read_log_tail(task["id"], max_lines=8)
+    if log_lines:
+        for line in log_lines:
+            lines.append(line + "\n", style="dim")
+    else:
+        lines.append("  (no logs yet)\n", style="dim")
+
+    return Panel(
+        lines,
+        box=HEAVY,
+        border_style="dim cyan",
+        expand=True,
+        padding=(0, 1),
+    )
+
+
+def _read_log_tail(task_id, max_lines=8):
+    """Read the last N lines from a task's orchestrator log."""
+    try:
+        sessions_dir = get_sessions_dir(task_id)
+        log_file = os.path.join(sessions_dir, "orchestrator.log")
+        if not os.path.isfile(log_file):
+            return []
+        with open(log_file, "r") as f:
+            all_lines = f.readlines()
+        return [line.rstrip() for line in all_lines[-max_lines:]]
+    except (OSError, IOError):
+        return []
+
+
+def _read_log_full(task_id):
+    """Read the full orchestrator log for a task."""
+    try:
+        sessions_dir = get_sessions_dir(task_id)
+        log_file = os.path.join(sessions_dir, "orchestrator.log")
+        if not os.path.isfile(log_file):
+            return []
+        with open(log_file, "r") as f:
+            return [line.rstrip() for line in f.readlines()]
+    except (OSError, IOError):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Footer builders
+# ---------------------------------------------------------------------------
+
+def _build_footer_main():
+    """Footer for the main session list view."""
+    from rich.text import Text
     footer = Text()
     keys = [
         ("j/k", "navigate"),
         ("Enter", "attach"),
         ("x", "stop"),
+        ("l", "logs"),
+        ("d", "detail"),
         ("r", "refresh"),
         ("q", "quit"),
     ]
@@ -166,6 +263,50 @@ def _build_footer():
         footer.append(key, style="bold bright_white")
         footer.append(" %s" % action, style="dim")
     return footer
+
+
+def _build_footer_detail():
+    """Footer for the detail panel view."""
+    from rich.text import Text
+    footer = Text()
+    keys = [
+        ("j/k", "navigate"),
+        ("d", "close detail"),
+        ("l", "full logs"),
+        ("q", "quit"),
+    ]
+    for i, (key, action) in enumerate(keys):
+        if i > 0:
+            footer.append("  ", style="dim")
+        footer.append(key, style="bold bright_white")
+        footer.append(" %s" % action, style="dim")
+    return footer
+
+
+def _build_footer_logs():
+    """Footer for the log viewer."""
+    from rich.text import Text
+    footer = Text()
+    keys = [
+        ("j/k", "scroll"),
+        ("G", "end"),
+        ("g", "top"),
+        ("q", "back"),
+    ]
+    for i, (key, action) in enumerate(keys):
+        if i > 0:
+            footer.append("  ", style="dim")
+        footer.append(key, style="bold bright_white")
+        footer.append(" %s" % action, style="dim")
+    return footer
+
+
+def _build_status_message(msg):
+    """Build a status message line."""
+    from rich.text import Text
+    if not msg:
+        return Text("")
+    return Text(msg, style="dim yellow")
 
 
 # ---------------------------------------------------------------------------
@@ -253,10 +394,8 @@ def _read_key(fd, timeout=2.0):
 
     b = ch[0] if isinstance(ch[0], int) else ord(ch[0])
 
-    # Enter
     if b in (10, 13):
         return "enter"
-    # Escape — could be bare Esc or start of arrow sequence
     if b == 27:
         ready2, _, _ = select.select([fd], [], [], 0.05)
         if ready2:
@@ -276,18 +415,189 @@ def _read_key(fd, timeout=2.0):
         return "stop"
     if b == ord("r"):
         return "refresh"
+    if b == ord("l"):
+        return "logs"
+    if b == ord("d") or b == ord(" "):
+        return "detail"
+    if b == ord("G"):
+        return "end"
+    if b == ord("g"):
+        return "top"
 
     return None
 
 
 # ---------------------------------------------------------------------------
-# Interactive TUI
+# Terminal helpers
+# ---------------------------------------------------------------------------
+
+_ENTER_ALT_SCREEN = "\x1b[?1049h"
+_EXIT_ALT_SCREEN = "\x1b[?1049l"
+_CLEAR_SCREEN = "\x1b[2J\x1b[H"
+_HIDE_CURSOR = "\x1b[?25l"
+_SHOW_CURSOR = "\x1b[?25h"
+
+
+def _enter_tui():
+    """Enter the alternate screen buffer and hide cursor."""
+    sys.stdout.write(_ENTER_ALT_SCREEN + _HIDE_CURSOR)
+    sys.stdout.flush()
+
+
+def _exit_tui():
+    """Exit the alternate screen buffer and show cursor."""
+    sys.stdout.write(_SHOW_CURSOR + _EXIT_ALT_SCREEN)
+    sys.stdout.flush()
+
+
+def _clear():
+    """Clear the alternate screen and move cursor to top-left."""
+    sys.stdout.write(_CLEAR_SCREEN)
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Safe action handlers (never crash, always return a status message)
+# ---------------------------------------------------------------------------
+
+def _do_attach(task):
+    """Try to attach to a task's tmux session. Returns a status message or None."""
+    tmux_session = "autopilot-%s" % task["id"]
+    try:
+        result = subprocess.run(
+            ["tmux", "switch-client", "-t", tmux_session],
+            capture_output=True, check=True,
+        )
+        return None
+    except subprocess.CalledProcessError:
+        pass
+    except FileNotFoundError:
+        return "tmux not available"
+
+    # Try attach as subprocess (NOT execvp — we want to return)
+    try:
+        result = subprocess.run(
+            ["tmux", "has-session", "-t", tmux_session],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            return "Session not running \u2014 task is %s" % task["state"]
+        # Session exists but switch-client failed (not inside tmux)
+        return "Run: tmux attach -t %s" % tmux_session
+    except FileNotFoundError:
+        return "tmux not available"
+
+
+def _do_stop(task):
+    """Try to stop a task. Returns a status message."""
+    if task["state"] in _TERMINAL_STATES:
+        return "Already %s" % task["state"].lower()
+
+    tmux_session = "autopilot-%s" % task["id"]
+    try:
+        subprocess.run(
+            ["tmux", "kill-session", "-t", tmux_session],
+            check=True, capture_output=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass  # Session may already be gone
+
+    update_task(task["id"], pre_stop_state=task["state"], state="STOPPED")
+    return "Stopped task %s" % task["id"]
+
+
+# ---------------------------------------------------------------------------
+# Log viewer TUI
+# ---------------------------------------------------------------------------
+
+def _logs_view(fd, old_settings, task_id, interval=2):
+    """Full-screen log viewer for a task. Returns when user presses q/Esc."""
+    import termios
+    import tty
+
+    from rich.box import HEAVY
+    from rich.console import Console, Group
+    from rich.panel import Panel
+    from rich.text import Text
+
+    scroll_offset = 0
+    lines = _read_log_full(task_id)
+    if not lines:
+        return "No logs available for task %s" % task_id
+
+    # Jump to end by default
+    console_height = os.get_terminal_size().lines - 6  # borders + footer
+    scroll_offset = max(0, len(lines) - console_height)
+
+    while True:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        _clear()
+
+        console = Console()
+        visible = lines[scroll_offset:scroll_offset + console_height]
+
+        log_text = Text()
+        for line in visible:
+            log_text.append(line + "\n", style="dim")
+
+        panel = Panel(
+            log_text,
+            title="[bold bright_white]Logs \u2014 Task %s[/]" % task_id,
+            box=HEAVY,
+            border_style="dim cyan",
+            expand=True,
+            padding=(0, 1),
+        )
+
+        position = Text()
+        position.append(
+            "  Line %d-%d of %d" % (
+                scroll_offset + 1,
+                min(scroll_offset + console_height, len(lines)),
+                len(lines),
+            ),
+            style="dim",
+        )
+
+        console.print(Group(panel, _build_footer_logs(), position))
+
+        tty.setraw(fd)
+        key = _read_key(fd, timeout=interval)
+
+        if key in ("quit", "esc"):
+            return None
+
+        if key == "down":
+            scroll_offset = min(scroll_offset + 1, max(0, len(lines) - console_height))
+        elif key == "up":
+            scroll_offset = max(scroll_offset - 1, 0)
+        elif key == "end":
+            scroll_offset = max(0, len(lines) - console_height)
+        elif key == "top":
+            scroll_offset = 0
+        elif key is None:
+            # Timeout — re-read log in case it grew
+            lines = _read_log_full(task_id)
+            if not lines:
+                return None
+
+
+# ---------------------------------------------------------------------------
+# Interactive TUI (main entry point)
 # ---------------------------------------------------------------------------
 
 def status_interactive(interval=2):
     """Full-screen interactive dashboard with keybindings.
 
-    Requires a TTY. Falls back to status_watch() if not a terminal.
+    Features:
+    - j/k navigate, Enter attach, x stop, l logs, d detail, r refresh, q quit
+    - Animated spinners for active states
+    - Detail panel toggle showing task metadata + log tail
+    - Full log viewer with j/k scroll
+    - Alternate screen buffer (no scrollback bleed)
+    - Safe actions with status messages (never crashes out of TUI)
+
+    Falls back to status_watch() if not a TTY or termios unavailable.
     """
     if not sys.stdin.isatty():
         status_watch(interval=interval)
@@ -311,43 +621,70 @@ def status_interactive(interval=2):
 
     selected = 0
     tick = 0
+    detail_open = False
+    status_msg = ""
+    status_msg_until = 0
 
-    def render(console):
+    def set_status(msg, duration=3):
+        nonlocal status_msg, status_msg_until
+        status_msg = msg
+        status_msg_until = time.time() + duration
+
+    def get_status():
+        if time.time() < status_msg_until:
+            return status_msg
+        return ""
+
+    def render_main(console):
         tasks = list_tasks()
         if not tasks:
             from rich.table import Table
             table = Table(title="[bold bright_white]autopilot-loop \u2014 No sessions[/]")
-            return Group(table, _build_footer()), tasks
+            footer = _build_footer_main()
+            msg = _build_status_message(get_status())
+            return Group(table, footer, msg), tasks
 
         sel = min(selected, len(tasks) - 1)
-        table = _build_table("autopilot-loop \u2014 Sessions", tasks,
-                             selected_idx=sel, tick=tick)
-        return Group(table, _build_footer()), tasks
+        title = "autopilot-loop \u2014 Sessions (%d)" % len(tasks)
+        table = _build_table(title, tasks, selected_idx=sel, tick=tick,
+                             compact=detail_open)
+
+        parts = [table]
+        if detail_open and tasks:
+            parts.append(_build_detail_panel(tasks[sel]))
+
+        footer = _build_footer_detail() if detail_open else _build_footer_main()
+        parts.append(footer)
+        msg_text = get_status()
+        if msg_text:
+            parts.append(_build_status_message(msg_text))
+
+        return Group(*parts), tasks
 
     try:
+        _enter_tui()
         tty.setraw(fd)
 
         while True:
-            # Temporarily restore cooked mode for rendering
+            # Restore cooked mode for rendering
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-
-            # Clear screen and move cursor to top-left
-            sys.stdout.write("\x1b[2J\x1b[H")
-            sys.stdout.flush()
+            _clear()
 
             console = Console()
-            content, tasks = render(console)
+            content, tasks = render_main(console)
             console.print(content)
 
             # Back to raw mode for key reading
             tty.setraw(fd)
-
             key = _read_key(fd, timeout=interval)
 
             if key in ("quit", "esc"):
-                break
+                if detail_open:
+                    detail_open = False
+                else:
+                    break
 
-            if key == "down":
+            elif key == "down":
                 tasks = list_tasks()
                 if tasks:
                     selected = min(selected + 1, len(tasks) - 1)
@@ -360,36 +697,28 @@ def status_interactive(interval=2):
             elif key == "enter":
                 tasks = list_tasks()
                 if tasks and 0 <= selected < len(tasks):
-                    task = tasks[selected]
-                    tmux_session = "autopilot-%s" % task["id"]
-                    termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-                    try:
-                        subprocess.run(
-                            ["tmux", "switch-client", "-t", tmux_session],
-                            check=True,
-                        )
-                    except subprocess.CalledProcessError:
-                        try:
-                            os.execvp("tmux", ["tmux", "attach", "-t", tmux_session])
-                        except FileNotFoundError:
-                            pass
+                    msg = _do_attach(tasks[selected])
+                    if msg:
+                        set_status(msg)
 
             elif key == "stop":
                 tasks = list_tasks()
                 if tasks and 0 <= selected < len(tasks):
-                    task = tasks[selected]
-                    if task["state"] not in ("COMPLETE", "FAILED", "STOPPED"):
-                        tmux_session = "autopilot-%s" % task["id"]
-                        try:
-                            subprocess.run(
-                                ["tmux", "kill-session", "-t", tmux_session],
-                                check=True, capture_output=True,
-                            )
-                        except (subprocess.CalledProcessError, FileNotFoundError):
-                            pass
-                        update_task(task["id"],
-                                    pre_stop_state=task["state"],
-                                    state="STOPPED")
+                    msg = _do_stop(tasks[selected])
+                    set_status(msg)
+
+            elif key == "detail":
+                detail_open = not detail_open
+
+            elif key == "logs":
+                tasks = list_tasks()
+                if tasks and 0 <= selected < len(tasks):
+                    msg = _logs_view(fd, old_settings, tasks[selected]["id"], interval)
+                    if msg:
+                        set_status(msg)
+
+            elif key == "refresh":
+                set_status("Refreshed")
 
             tick += 1
 
@@ -397,6 +726,4 @@ def status_interactive(interval=2):
         pass
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-        # Clear screen on exit
-        sys.stdout.write("\x1b[2J\x1b[H")
-        sys.stdout.flush()
+        _exit_tui()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,356 @@
+"""Tests for the dashboard rendering functions."""
+
+import os
+import time
+
+import pytest
+
+from autopilot_loop import persistence
+from autopilot_loop.dashboard import (
+    _STATIC_INDICATORS,
+    _WAITING_FRAMES,
+    _WAITING_STATES,
+    _WORKING_FRAMES,
+    _WORKING_STATES,
+    _build_detail_panel,
+    _build_footer_detail,
+    _build_footer_logs,
+    _build_footer_main,
+    _build_status_message,
+    _build_table,
+    _format_elapsed,
+    _get_indicator,
+    _read_key,
+    _read_log_tail,
+)
+
+
+@pytest.fixture(autouse=True)
+def use_temp_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(persistence, "DB_DIR", str(tmp_path))
+    monkeypatch.setattr(persistence, "DB_PATH", str(tmp_path / "state.db"))
+
+
+# ---------------------------------------------------------------------------
+# _format_elapsed
+# ---------------------------------------------------------------------------
+
+class TestFormatElapsed:
+    def test_under_one_minute(self):
+        assert _format_elapsed(time.time() - 30) == "< 1m"
+
+    def test_minutes(self):
+        result = _format_elapsed(time.time() - 600)
+        assert result == "10m"
+
+    def test_hours(self):
+        result = _format_elapsed(time.time() - 7200)
+        assert "2.0h" in result
+
+
+# ---------------------------------------------------------------------------
+# _get_indicator
+# ---------------------------------------------------------------------------
+
+class TestGetIndicator:
+    def test_working_state_cycles(self):
+        indicators = [_get_indicator("IMPLEMENT", t) for t in range(20)]
+        # Should cycle through working frames
+        assert indicators[0] == _WORKING_FRAMES[0]
+        assert indicators[1] == _WORKING_FRAMES[1]
+
+    def test_waiting_state_cycles(self):
+        indicators = [_get_indicator("WAIT_REVIEW", t) for t in range(8)]
+        assert indicators[0] == _WAITING_FRAMES[0]
+        assert indicators[4] == _WAITING_FRAMES[0]  # Wraps at len 4
+
+    def test_complete_static(self):
+        assert _get_indicator("COMPLETE", 0) == _STATIC_INDICATORS["COMPLETE"]
+        assert _get_indicator("COMPLETE", 99) == _STATIC_INDICATORS["COMPLETE"]
+
+    def test_failed_static(self):
+        assert _get_indicator("FAILED", 0) == _STATIC_INDICATORS["FAILED"]
+
+    def test_stopped_static(self):
+        assert _get_indicator("STOPPED", 0) == _STATIC_INDICATORS["STOPPED"]
+
+    def test_all_working_states_animate(self):
+        for state in _WORKING_STATES:
+            i0 = _get_indicator(state, 0)
+            i1 = _get_indicator(state, 1)
+            assert i0 in _WORKING_FRAMES
+            assert i1 in _WORKING_FRAMES
+
+    def test_all_waiting_states_animate(self):
+        for state in _WAITING_STATES:
+            i0 = _get_indicator(state, 0)
+            assert i0 in _WAITING_FRAMES
+
+
+# ---------------------------------------------------------------------------
+# _build_table
+# ---------------------------------------------------------------------------
+
+class TestBuildTable:
+    def _make_task(self, task_id="t1", state="IMPLEMENT", pr_number=None,
+                   branch="autopilot/t1"):
+        now = time.time()
+        return {
+            "id": task_id, "state": state, "pr_number": pr_number,
+            "branch": branch, "iteration": 1, "max_iterations": 5,
+            "task_mode": "review", "created_at": now,
+        }
+
+    def test_empty_tasks(self):
+        table = _build_table("Test", [])
+        assert table.row_count == 0
+
+    def test_single_task(self):
+        tasks = [self._make_task()]
+        table = _build_table("Test", tasks)
+        assert table.row_count == 1
+
+    def test_selected_row(self):
+        tasks = [self._make_task("t1"), self._make_task("t2")]
+        table = _build_table("Test", tasks, selected_idx=1)
+        assert table.row_count == 2
+
+    def test_compact_mode(self):
+        tasks = [self._make_task()]
+        table = _build_table("Test", tasks, compact=True)
+        assert table.row_count == 1
+
+    def test_long_branch_truncated(self):
+        tasks = [self._make_task(branch="autopilot/very-long-branch-name-that-exceeds-thirty-characters")]
+        table = _build_table("Test", tasks)
+        assert table.row_count == 1
+
+    def test_tick_advances_spinner(self):
+        tasks = [self._make_task(state="IMPLEMENT")]
+        t0 = _build_table("Test", tasks, tick=0)
+        t1 = _build_table("Test", tasks, tick=1)
+        # Tables should differ (different spinner frame)
+        assert t0 is not t1
+
+
+# ---------------------------------------------------------------------------
+# _build_detail_panel
+# ---------------------------------------------------------------------------
+
+class TestBuildDetailPanel:
+    def test_renders_without_error(self):
+        task = {
+            "id": "abc123", "state": "IMPLEMENT", "task_mode": "review",
+            "branch": "autopilot/abc123", "pr_number": None,
+            "iteration": 0, "max_iterations": 5,
+            "created_at": time.time(),
+        }
+        panel = _build_detail_panel(task)
+        assert panel is not None
+
+    def test_with_pr_number(self):
+        task = {
+            "id": "abc123", "state": "WAIT_REVIEW", "task_mode": "review",
+            "branch": "autopilot/abc123", "pr_number": 42,
+            "iteration": 1, "max_iterations": 5,
+            "created_at": time.time() - 300,
+        }
+        panel = _build_detail_panel(task)
+        assert panel is not None
+
+
+# ---------------------------------------------------------------------------
+# _read_log_tail
+# ---------------------------------------------------------------------------
+
+class TestReadLogTail:
+    def test_no_log_file(self):
+        assert _read_log_tail("nonexistent") == []
+
+    def test_reads_tail(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(persistence, "DB_DIR", str(tmp_path))
+        sessions_dir = tmp_path / "sessions" / "t1"
+        sessions_dir.mkdir(parents=True)
+        log_file = sessions_dir / "orchestrator.log"
+        lines = ["line %d" % i for i in range(20)]
+        log_file.write_text("\n".join(lines) + "\n")
+        result = _read_log_tail("t1", max_lines=5)
+        assert len(result) == 5
+        assert result[-1] == "line 19"
+
+
+# ---------------------------------------------------------------------------
+# Footer builders
+# ---------------------------------------------------------------------------
+
+class TestFooters:
+    def test_main_footer_has_all_keys(self):
+        footer = _build_footer_main()
+        text = str(footer)
+        for key in ["j/k", "Enter", "x", "l", "d", "r", "q"]:
+            assert key in text
+
+    def test_detail_footer_has_close(self):
+        footer = _build_footer_detail()
+        text = str(footer)
+        assert "close" in text
+
+    def test_logs_footer_has_scroll(self):
+        footer = _build_footer_logs()
+        text = str(footer)
+        assert "scroll" in text
+        assert "G" in text
+
+    def test_status_message_empty(self):
+        msg = _build_status_message("")
+        assert str(msg) == ""
+
+    def test_status_message_content(self):
+        msg = _build_status_message("Session not running")
+        assert "Session not running" in str(msg)
+
+
+# ---------------------------------------------------------------------------
+# _read_key (unit test with mock fd)
+# ---------------------------------------------------------------------------
+
+class TestReadKey:
+    def test_timeout_returns_none(self):
+        # Use a real pipe to test timeout
+        r, w = os.pipe()
+        try:
+            result = _read_key(r, timeout=0.05)
+            assert result is None
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_j_returns_down(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"j")
+            result = _read_key(r, timeout=0.1)
+            assert result == "down"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_k_returns_up(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"k")
+            result = _read_key(r, timeout=0.1)
+            assert result == "up"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_q_returns_quit(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"q")
+            result = _read_key(r, timeout=0.1)
+            assert result == "quit"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_x_returns_stop(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"x")
+            result = _read_key(r, timeout=0.1)
+            assert result == "stop"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_r_returns_refresh(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"r")
+            result = _read_key(r, timeout=0.1)
+            assert result == "refresh"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_l_returns_logs(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"l")
+            result = _read_key(r, timeout=0.1)
+            assert result == "logs"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_d_returns_detail(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"d")
+            result = _read_key(r, timeout=0.1)
+            assert result == "detail"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_enter_returns_enter(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"\n")
+            result = _read_key(r, timeout=0.1)
+            assert result == "enter"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_arrow_up(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"\x1b[A")
+            result = _read_key(r, timeout=0.1)
+            assert result == "up"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_arrow_down(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"\x1b[B")
+            result = _read_key(r, timeout=0.1)
+            assert result == "down"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_G_returns_end(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"G")
+            result = _read_key(r, timeout=0.1)
+            assert result == "end"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_g_returns_top(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"g")
+            result = _read_key(r, timeout=0.1)
+            assert result == "top"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_unknown_key_returns_none(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"z")
+            result = _read_key(r, timeout=0.1)
+            assert result is None
+        finally:
+            os.close(r)
+            os.close(w)


### PR DESCRIPTION
## Summary

Major TUI polish: alternate screen buffer, safe actions, detail panel, built-in log viewer. Closes #11.

### Alternate Screen Buffer
- Uses `ESC[?1049h` / `ESC[?1049l` to isolate the TUI from terminal scrollback history
- Previous renders are no longer visible when scrolling up — the dashboard is a clean, stable screen
- Cursor hidden during TUI, always restored in a `finally` block

### HEAVY Borders + Row Padding
- Switched from `ROUNDED` to `HEAVY` box style — thick borders that pop on dark terminals
- Added vertical padding between rows for visual breathing room
- Session count shown in title: `"Sessions (3)"`

### Safe Action Handlers
Every keybinding action catches errors and shows a temporary status message instead of crashing:
- `Enter` on a dead session → "Session not running — task is COMPLETE"
- `x` on a completed task → "Already complete"
- tmux not available → "tmux not available"
- `os.execvp` completely removed — all tmux operations use `subprocess.run`
- Status messages auto-clear after 3 seconds

### Detail Panel (`d` / `Space`)
Split-pane preview showing task metadata + log tail:
- Branch, state, PR, iteration, elapsed time
- Last 8 lines from orchestrator.log (live tail)
- Table switches to compact mode when panel is open
- Press `d` again or `Esc` to close

### Log Viewer (`l`)
Full-screen scrollable log viewer:
- `j`/`k` to scroll, `G` to jump to end, `g` to jump to top
- Auto-refreshes log content on timeout (catches new lines from active tasks)
- Position indicator: "Line 45-80 of 120"
- `q`/`Esc` returns to session list

### Dynamic Footer
Changes based on current view mode:
- Main: `j/k navigate  Enter attach  x stop  l logs  d detail  r refresh  q quit`
- Detail: `j/k navigate  d close detail  l full logs  q quit`
- Logs: `j/k scroll  G end  g top  q back`

### Tests
- **39 new tests** in `test_dashboard.py` covering:
  - Spinner animation cycling for all working/waiting states
  - Table building with selection, compact mode, long branch truncation
  - Detail panel rendering with/without PR
  - Log tail reading from disk
  - All footer builders
  - Status message rendering
  - Key reading with deterministic pipe-based input simulation (all 14 key bindings)
- **136 tests total**, all passing, ruff clean

### Docs Updated
- README: Full keybinding tables for session list view and log viewer
- copilot-instructions: Added TUI safety conventions (no execvp, alternate screen, finally blocks)
