### PR TITLE
Add idle_timeout_enabled config option

### DIFF
--- a/autopilot.example.json
+++ b/autopilot.example.json
@@ -7,6 +7,7 @@
   "review_timeout_seconds": 3600,
   "agent_timeout_seconds": 1800,
   "idle_timeout_minutes": 120,
+  "idle_timeout_enabled": true,
   "keepalive_enabled": false,
   "keepalive_interval_seconds": 300,
   "branch_pattern": "autopilot/{task_id}",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,7 @@ Search order (first found wins):
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `idle_timeout_minutes` | int | `120` | Codespace idle timeout to set when a task starts. Only applied if the current timeout is lower. Capped by org policy. |
+| `idle_timeout_enabled` | bool | `true` | Set to `false` to skip idle timeout extension entirely. Useful for repos where you don't want tasks to keep Codespaces alive longer. |
 | `keepalive_enabled` | bool | `false` | Enable a background heartbeat thread as a fallback if the idle timeout API doesn't work. |
 | `keepalive_interval_seconds` | int | `300` | Heartbeat interval when keepalive is enabled. |
 

--- a/src/autopilot_loop/config.py
+++ b/src/autopilot_loop/config.py
@@ -21,6 +21,7 @@ DEFAULTS = {
     "review_timeout_seconds": 3600,
     "agent_timeout_seconds": 1800,
     "idle_timeout_minutes": 120,
+    "idle_timeout_enabled": True,
     "keepalive_enabled": False,
     "keepalive_interval_seconds": 300,
     "branch_pattern": "autopilot/{task_id}",

--- a/src/autopilot_loop/orchestrator.py
+++ b/src/autopilot_loop/orchestrator.py
@@ -116,13 +116,16 @@ class BaseOrchestrator:
         """Validate config, create session dir, set codespace idle timeout."""
         logger.info("[%s] INIT \u2192 Validated config, created session dir", self.task_id)
 
-        # Set codespace idle timeout (non-fatal)
-        try:
-            set_idle_timeout(self.config.get("idle_timeout_minutes", 120))
-            logger.info("[%s] \u2713 Codespace idle timeout set to %d minutes",
-                        self.task_id, self.config.get("idle_timeout_minutes", 120))
-        except Exception as e:
-            logger.warning("[%s] Could not set codespace idle timeout: %s", self.task_id, e)
+        # Set codespace idle timeout (non-fatal, can be disabled via config)
+        if self.config.get("idle_timeout_enabled", True):
+            try:
+                set_idle_timeout(self.config.get("idle_timeout_minutes", 120))
+                logger.info("[%s] \u2713 Codespace idle timeout set to %d minutes",
+                            self.task_id, self.config.get("idle_timeout_minutes", 120))
+            except Exception as e:
+                logger.warning("[%s] Could not set codespace idle timeout: %s", self.task_id, e)
+        else:
+            logger.info("[%s] Idle timeout extension disabled by config", self.task_id)
 
         return self._init_next_state()
 


### PR DESCRIPTION
Allows disabling codespace idle timeout extension per-repo by setting `idle_timeout_enabled: false` in `autopilot.json`. Default is `true` (existing behavior unchanged).

Changes:
- Added `idle_timeout_enabled` to `DEFAULTS` in `config.py` (default: `true`)
- Guard in `Orchestrator._do_init()` skips `set_idle_timeout()` when disabled
- Updated `autopilot.example.json` and `docs/configuration.md`

Closes #19