### PR TITLE
Auto-discover sibling repos in workspace for agent context

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,12 @@ Search order (first found wins):
 | `branch_pattern` | string | `"autopilot/{task_id}"` | Branch naming pattern. Must contain `{task_id}`. |
 | `custom_instructions` | string | `""` | Extra instructions appended to every agent prompt. Use for repo-specific context (test commands, lint rules, etc.). |
 
+### Workspace
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `add_dirs` | list or null | `null` (auto) | Directories to give the agent read access to via `--add-dir`. By default, all sibling git repos in the workspace are auto-discovered. Set to `[]` to disable, or `["/path/to/repo"]` to override. |
+
 ### Review Loop
 
 | Field | Type | Default | Description |

--- a/src/autopilot_loop/orchestrator.py
+++ b/src/autopilot_loop/orchestrator.py
@@ -133,6 +133,37 @@ class BaseOrchestrator:
         """Return the state to transition to after INIT. Subclasses must override."""
         raise NotImplementedError
 
+    def _get_extra_flags(self):
+        """Build extra CLI flags for the agent (e.g. --add-dir for sibling repos)."""
+        flags = []
+        for d in self._get_workspace_dirs():
+            flags.extend(["--add-dir", d])
+        return flags if flags else None
+
+    def _get_workspace_dirs(self):
+        """Discover sibling git repos in the workspace to give the agent read access.
+
+        Auto-detects repos under the parent of CWD (e.g. /workspaces/*/).
+        Excludes the current repo. Can be overridden via config add_dirs.
+        """
+        configured = self.config.get("add_dirs")
+        if configured is not None:
+            return configured
+
+        cwd = os.getcwd()
+        parent = os.path.dirname(cwd)
+        dirs = []
+        try:
+            for name in os.listdir(parent):
+                candidate = os.path.join(parent, name)
+                if candidate == cwd:
+                    continue
+                if os.path.isdir(os.path.join(candidate, ".git")):
+                    dirs.append(candidate)
+        except OSError:
+            pass
+        return dirs
+
     def _run_agent_with_retry(self, phase, prompt, session_name):
         """Run an agent with retry policy.
 
@@ -156,6 +187,7 @@ class BaseOrchestrator:
                 session_dir=phase_session_dir,
                 model=self.config.get("model", "claude-opus-4.6"),
                 timeout=self.config.get("agent_timeout_seconds", 1800),
+                extra_flags=self._get_extra_flags(),
             )
             ended_at = time.time()
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -617,3 +617,94 @@ class TestIdleTimeoutEnabled:
         orch = Orchestrator(task_id, config)
         orch._do_init()
         mock_timeout.assert_not_called()
+
+
+class TestWorkspaceDirs:
+    def test_auto_discovers_sibling_repos(self, tmp_path, monkeypatch, config):
+        """Discovers sibling git repos under the parent directory."""
+        # Create workspace layout: /workspace/repo-a (cwd), /workspace/repo-b (sibling)
+        repo_a = tmp_path / "repo-a"
+        repo_b = tmp_path / "repo-b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+        (repo_a / ".git").mkdir()
+        (repo_b / ".git").mkdir()
+
+        monkeypatch.chdir(repo_a)
+        task_id = _create_test_task()
+        orch = Orchestrator(task_id, config)
+        dirs = orch._get_workspace_dirs()
+        assert str(repo_b) in dirs
+        assert str(repo_a) not in dirs
+
+    def test_ignores_non_git_dirs(self, tmp_path, monkeypatch, config):
+        """Non-git directories are not included."""
+        repo = tmp_path / "repo"
+        plain = tmp_path / "plain-dir"
+        repo.mkdir()
+        plain.mkdir()
+        (repo / ".git").mkdir()
+        # plain has no .git
+
+        monkeypatch.chdir(repo)
+        task_id = _create_test_task()
+        orch = Orchestrator(task_id, config)
+        dirs = orch._get_workspace_dirs()
+        assert str(plain) not in dirs
+
+    def test_config_override_replaces_auto(self, tmp_path, monkeypatch, config):
+        """add_dirs config overrides auto-discovery."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        monkeypatch.chdir(repo)
+        config["add_dirs"] = ["/custom/path"]
+        task_id = _create_test_task()
+        orch = Orchestrator(task_id, config)
+        dirs = orch._get_workspace_dirs()
+        assert dirs == ["/custom/path"]
+
+    def test_config_empty_list_disables(self, tmp_path, monkeypatch, config):
+        """add_dirs: [] disables auto-discovery."""
+        repo_a = tmp_path / "repo-a"
+        repo_b = tmp_path / "repo-b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+        (repo_a / ".git").mkdir()
+        (repo_b / ".git").mkdir()
+
+        monkeypatch.chdir(repo_a)
+        config["add_dirs"] = []
+        task_id = _create_test_task()
+        orch = Orchestrator(task_id, config)
+        dirs = orch._get_workspace_dirs()
+        assert dirs == []
+
+    def test_extra_flags_built_from_dirs(self, tmp_path, monkeypatch, config):
+        """_get_extra_flags() produces --add-dir pairs."""
+        repo_a = tmp_path / "repo-a"
+        repo_b = tmp_path / "repo-b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+        (repo_a / ".git").mkdir()
+        (repo_b / ".git").mkdir()
+
+        monkeypatch.chdir(repo_a)
+        task_id = _create_test_task()
+        orch = Orchestrator(task_id, config)
+        flags = orch._get_extra_flags()
+        assert "--add-dir" in flags
+        assert str(repo_b) in flags
+
+    def test_no_siblings_returns_none(self, tmp_path, monkeypatch, config):
+        """No sibling repos returns None (no extra flags)."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        monkeypatch.chdir(repo)
+        task_id = _create_test_task()
+        orch = Orchestrator(task_id, config)
+        flags = orch._get_extra_flags()
+        assert flags is None


### PR DESCRIPTION
Every `copilot -p` invocation now automatically gets `--add-dir` flags for sibling git repos in the workspace. This gives the agent read access to related repos (e.g. a frontend repo while working in the backend) without making changes there.

**Zero config for the common case** — just works in multi-repo Codespace workspaces.

### Behavior
- Auto-discovers `.git` dirs under parent of CWD (e.g. `/workspaces/*/`)
- Excludes current repo (already the agent's CWD)
- Configurable: `"add_dirs": []` in `autopilot.json` to disable, or `"add_dirs": ["/path"]` to override

### Tests
6 new tests (157 -> 163 total) covering auto-discovery, non-git filtering, config override, empty list disable, flag building, and no-sibling case.