### PR TITLE
Carry forward fix context between iterations

### DIFF
--- a/src/autopilot_loop/orchestrator.py
+++ b/src/autopilot_loop/orchestrator.py
@@ -462,6 +462,53 @@ class Orchestrator(BaseOrchestrator):
 
         return "FIX"
 
+    def _load_previous_fix_summary(self, current_iteration):
+        """Load the previous iteration's fix summary for context carry-forward.
+
+        Returns a formatted string describing what the previous agent decided,
+        or empty string if no previous summary exists.
+        """
+        prev_iteration = current_iteration - 1
+        if prev_iteration < 1:
+            return ""
+
+        summary_path = os.path.join(self.sessions_dir, "fix-summary-%d.json" % prev_iteration)
+        if not os.path.isfile(summary_path):
+            return ""
+
+        try:
+            with open(summary_path, "r") as f:
+                entries = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return ""
+
+        if not entries:
+            return ""
+
+        lines = [
+            "In iteration %d, the agent made these decisions:" % prev_iteration,
+            "",
+        ]
+        for entry in entries:
+            cid = entry.get("comment_id", "?")
+            status = entry.get("status", "unknown")
+            message = entry.get("message", "")
+            if status == "fixed":
+                lines.append("- Comment %s: FIXED — %s" % (cid, message or "no details"))
+            elif status == "skipped":
+                lines.append("- Comment %s: SKIPPED — %s" % (cid, message or "no reason given"))
+            else:
+                lines.append("- Comment %s: %s — %s" % (cid, status.upper(), message))
+
+        lines.append("")
+        lines.append(
+            "The comments below are STILL unresolved after re-review. "
+            "The previous fix may not have fully addressed the concern, "
+            "or Copilot found new issues. Adjust your approach accordingly."
+        )
+
+        return "\n".join(lines)
+
     def _do_fix(self):
         """Run copilot agent to address review comments."""
         pr_number = self.task["pr_number"]
@@ -476,11 +523,15 @@ class Orchestrator(BaseOrchestrator):
         review = get_copilot_review(pr_number)
         review_body = review.get("body", "") if review else ""
 
+        # Load previous iteration's fix summary for context carry-forward
+        previous_context = self._load_previous_fix_summary(iteration)
+
         # Format for prompt
         review_text = format_review_for_prompt(review_body, unresolved)
         prompt = fix_prompt(
             review_comments_text=review_text,
             custom_instructions=self.config.get("custom_instructions", ""),
+            previous_context=previous_context,
         )
 
         # Record head SHA before fix
@@ -509,6 +560,12 @@ class Orchestrator(BaseOrchestrator):
                     if cid is not None:
                         summaries[int(cid)] = entry
                 logger.info("[%s] Loaded fix summary: %d entries", self.task_id, len(summaries))
+
+                # Persist to sessions dir for context carry-forward to next iteration
+                import shutil
+                iteration = self.task["iteration"]
+                saved = os.path.join(self.sessions_dir, "fix-summary-%d.json" % iteration)
+                shutil.copy2(summary_file, saved)
             except (json.JSONDecodeError, KeyError) as e:
                 logger.warning("[%s] Could not parse fix summary: %s", self.task_id, e)
 

--- a/src/autopilot_loop/prompts.py
+++ b/src/autopilot_loop/prompts.py
@@ -129,7 +129,7 @@ def plan_and_implement_prompt(task_description, branch_name, custom_instructions
     return "\n".join(parts)
 
 
-def fix_prompt(review_comments_text, custom_instructions=""):
+def fix_prompt(review_comments_text, custom_instructions="", previous_context=""):
     """Prompt for the FIX phase.
 
     Agent addresses PR review comments, commits, pushes, self-reviews,
@@ -139,6 +139,12 @@ def fix_prompt(review_comments_text, custom_instructions=""):
 
     if custom_instructions:
         parts.append(custom_instructions.strip())
+        parts.append("")
+
+    if previous_context:
+        parts.append("## Previous Iteration Context")
+        parts.append("")
+        parts.append(previous_context.strip())
         parts.append("")
 
     parts.append("## Copilot Review Feedback to Address")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,5 +1,6 @@
 """Tests for the orchestrator state machine."""
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -617,6 +618,62 @@ class TestIdleTimeoutEnabled:
         orch = Orchestrator(task_id, config)
         orch._do_init()
         mock_timeout.assert_not_called()
+
+
+class TestFixContextCarryForward:
+    def test_no_previous_summary_returns_empty(self, config):
+        """First iteration has no previous context."""
+        task_id = _create_test_task()
+        persistence.update_task(task_id, iteration=1)
+        orch = Orchestrator(task_id, config)
+        assert orch._load_previous_fix_summary(1) == ""
+
+    def test_loads_previous_summary(self, config):
+        """Loads and formats the previous iteration's fix summary."""
+        import json as _json
+
+        task_id = _create_test_task()
+        orch = Orchestrator(task_id, config)
+
+        # Write a fake fix summary for iteration 1
+        summary = [
+            {"comment_id": 42, "status": "fixed", "message": "Extracted billing concern"},
+            {"comment_id": 43, "status": "skipped", "message": "Current pattern is idiomatic"},
+        ]
+        summary_path = os.path.join(orch.sessions_dir, "fix-summary-1.json")
+        with open(summary_path, "w") as f:
+            _json.dump(summary, f)
+
+        result = orch._load_previous_fix_summary(2)
+        assert "Comment 42: FIXED" in result
+        assert "Extracted billing concern" in result
+        assert "Comment 43: SKIPPED" in result
+        assert "Current pattern is idiomatic" in result
+        assert "STILL unresolved" in result
+
+    def test_missing_summary_file_returns_empty(self, config):
+        """Returns empty string if summary file doesn't exist."""
+        task_id = _create_test_task()
+        orch = Orchestrator(task_id, config)
+        assert orch._load_previous_fix_summary(3) == ""
+
+
+class TestFixPromptPreviousContext:
+    def test_previous_context_included_in_prompt(self):
+        """fix_prompt includes previous context when provided."""
+        from autopilot_loop.prompts import fix_prompt
+        prompt = fix_prompt(
+            review_comments_text="some comments",
+            previous_context="- Comment 42: FIXED — did a thing",
+        )
+        assert "Previous Iteration Context" in prompt
+        assert "Comment 42: FIXED" in prompt
+
+    def test_no_previous_context(self):
+        """fix_prompt omits section when no previous context."""
+        from autopilot_loop.prompts import fix_prompt
+        prompt = fix_prompt(review_comments_text="some comments")
+        assert "Previous Iteration Context" not in prompt
 
 
 class TestWorkspaceDirs:


### PR DESCRIPTION
Each `copilot -p` invocation is a blank slate -- the agent doesn't know what previous iterations decided. This means iteration 3 might retry the exact same fix that iteration 2 already attempted and Copilot rejected.

**Now the fix prompt includes context from the previous iteration's decisions.**

### How It Works
1. `_do_resolve_comments` saves `fix-summary-N.json` to the sessions dir
2. `_do_fix` loads the previous iteration's summary via `_load_previous_fix_summary()`
3. `fix_prompt()` accepts a `previous_context` param and adds a **Previous Iteration Context** section

### What The Agent Sees

```
## Previous Iteration Context

In iteration 1, the agent made these decisions:

- Comment 42: FIXED -- Extracted billing concern
- Comment 43: SKIPPED -- Current pattern is idiomatic

The comments below are STILL unresolved after re-review.
The previous fix may not have fully addressed the concern.
Adjust your approach accordingly.
```

### Tests
5 new tests (163 -> 168 total):
- `TestFixContextCarryForward`: no previous summary, loads summary, missing file
- `TestFixPromptPreviousContext`: included when provided, omitted when empty
