### PR TITLE
fix: get_failed_checks silently swallows API errors

### DIFF
--- a/src/autopilot_loop/cli.py
+++ b/src/autopilot_loop/cli.py
@@ -420,6 +420,17 @@ def cmd_fix_ci(args):
 
     # Get failed checks
     failed_checks = get_failed_checks(args.pr)
+    if failed_checks is None:
+        print(
+            "Error: could not fetch CI checks for PR #%d." % args.pr,
+            file=sys.stderr,
+        )
+        print(
+            "This may be a permissions issue. "
+            "Run `gh auth status` to verify token scopes.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if not failed_checks:
         print("No failed CI checks found on PR #%d" % args.pr)
         return

--- a/src/autopilot_loop/github_api.py
+++ b/src/autopilot_loop/github_api.py
@@ -252,7 +252,11 @@ def get_unresolved_review_comments(pr_number):
     if not output:
         return []
 
-    data = json.loads(output)
+    try:
+        data = json.loads(output)
+    except ValueError:
+        logger.warning("Failed to parse GraphQL response in get_unresolved_review_comments")
+        return []
 
     # Check for GraphQL errors
     if "errors" in data:
@@ -305,8 +309,16 @@ def _strip_ansi(text):
     return _ANSI_RE.sub("", text)
 
 
-def get_failed_checks(pr_number):
-    """Get failed CI checks for a PR.
+_NON_FAILING_STATES = frozenset({"SUCCESS", "PENDING", "SKIPPED", "EXPECTED"})
+
+# Conclusions from the REST check-runs API that indicate failure.
+_FAILING_CONCLUSIONS = frozenset({
+    "failure", "timed_out", "cancelled", "action_required", "startup_failure",
+})
+
+
+def _parse_checks(raw_checks):
+    """Parse raw check dicts into the standardised format.
 
     Excludes aggregation gate checks (names ending in '-results').
     Parses run_id and job_id from the check link URL.
@@ -314,27 +326,15 @@ def get_failed_checks(pr_number):
     Returns:
         List of dicts with {name, link, run_id, job_id}.
     """
-    output = _run_gh([
-        "pr", "checks", str(pr_number),
-        "--json", "name,state,link",
-        "--jq", '[.[] | select(.state == "FAILURE")]',
-    ], check=False)
-
-    if not output:
-        return []
-
-    raw_checks = json.loads(output)
     checks = []
     for c in raw_checks:
         name = c.get("name", "")
-        # Skip aggregation gates (e.g., "build-results", "test-results")
         if name.endswith("-results"):
             continue
 
-        link = c.get("link", "")
+        link = c.get("link", "") or c.get("html_url", "")
         run_id = None
         job_id = None
-        # Parse from URL: /actions/runs/{run_id}/job/{job_id}
         m = re.search(r"/actions/runs/(\d+)/job/(\d+)", link)
         if m:
             run_id = int(m.group(1))
@@ -346,8 +346,72 @@ def get_failed_checks(pr_number):
             "run_id": run_id,
             "job_id": job_id,
         })
-
     return checks
+
+
+def _get_failed_checks_rest(pr_number):
+    """Fallback: fetch failed checks via REST API.
+
+    Uses ``gh pr view`` to obtain the HEAD SHA, then queries the
+    check-runs endpoint.  Returns None on any error.
+    """
+    try:
+        sha = _run_gh([
+            "pr", "view", str(pr_number),
+            "--json", "headRefOid", "--jq", ".headRefOid",
+        ])
+        if not sha:
+            return None
+        nwo = get_repo_nwo()
+        output = _run_gh([
+            "api", "repos/%s/commits/%s/check-runs" % (nwo, sha),
+            "--jq", ".check_runs",
+        ])
+        if not output:
+            return None
+        raw = json.loads(output)
+        failed = [
+            c for c in raw
+            if c.get("conclusion") in _FAILING_CONCLUSIONS
+        ]
+        return _parse_checks(failed)
+    except (GitHubAPIError, ValueError):
+        logger.debug("REST fallback for get_failed_checks also failed")
+        return None
+
+
+def get_failed_checks(pr_number):
+    """Get failed CI checks for a PR.
+
+    Tries ``gh pr checks`` first.  If that fails (e.g. due to
+    permission errors), falls back to the REST check-runs API.
+
+    Returns:
+        List of dicts with {name, link, run_id, job_id}, or
+        None if the CI check status could not be fetched.
+    """
+    try:
+        output = _run_gh([
+            "pr", "checks", str(pr_number),
+            "--json", "name,state,link",
+            "--jq",
+            '[.[] | select(.state != "SUCCESS" and .state != "PENDING"'
+            ' and .state != "SKIPPED" and .state != "EXPECTED")]',
+        ])
+    except GitHubAPIError as exc:
+        logger.warning("gh pr checks failed, trying REST fallback: %s", exc)
+        return _get_failed_checks_rest(pr_number)
+
+    if not output:
+        return []
+
+    try:
+        raw_checks = json.loads(output)
+    except ValueError:
+        logger.warning("Failed to parse gh pr checks output")
+        return _get_failed_checks_rest(pr_number)
+
+    return _parse_checks(raw_checks)
 
 
 def get_check_annotations(job_ids):
@@ -375,7 +439,11 @@ def get_check_annotations(job_ids):
         if not output:
             continue
 
-        raw = json.loads(output)
+        try:
+            raw = json.loads(output)
+        except ValueError:
+            logger.warning("Failed to parse annotations for job %d", job_id)
+            continue
         for ann in raw:
             if ann.get("annotation_level") != "failure":
                 continue
@@ -413,16 +481,27 @@ def get_check_states(pr_number, check_names):
         check_names: List of check names to query.
 
     Returns:
-        Dict mapping check name to state string (e.g., 'SUCCESS', 'FAILURE', 'PENDING').
+        Dict mapping check name to state string
+        (e.g., 'SUCCESS', 'FAILURE', 'PENDING'),
+        or None if the API call failed.
     """
-    output = _run_gh([
-        "pr", "checks", str(pr_number),
-        "--json", "name,state",
-    ], check=False)
+    try:
+        output = _run_gh([
+            "pr", "checks", str(pr_number),
+            "--json", "name,state",
+        ])
+    except GitHubAPIError as exc:
+        logger.warning("gh pr checks failed in get_check_states: %s", exc)
+        return None
 
     if not output:
         return {name: "UNKNOWN" for name in check_names}
 
-    raw = json.loads(output)
+    try:
+        raw = json.loads(output)
+    except ValueError:
+        logger.warning("Failed to parse gh pr checks output in get_check_states")
+        return None
+
     state_map = {c["name"]: c["state"] for c in raw}
     return {name: state_map.get(name, "UNKNOWN") for name in check_names}

--- a/src/autopilot_loop/orchestrator.py
+++ b/src/autopilot_loop/orchestrator.py
@@ -668,6 +668,9 @@ class CIOrchestrator(BaseOrchestrator):
 
         # Get current failed checks to find job IDs
         all_failed = get_failed_checks(pr_number)
+        if all_failed is None:
+            logger.error("[%s] Could not fetch CI checks (API error)", self.task_id)
+            return "FAILED"
         selected = [c for c in all_failed if c["name"] in ci_check_names]
 
         # Collect job IDs for annotation fetching
@@ -676,6 +679,9 @@ class CIOrchestrator(BaseOrchestrator):
         if not job_ids:
             # Check if the selected checks are now passing
             states = get_check_states(pr_number, ci_check_names)
+            if states is None:
+                logger.error("[%s] Could not fetch check states (API error)", self.task_id)
+                return "FAILED"
             all_passing = all(s == "SUCCESS" for s in states.values())
             if all_passing:
                 logger.info("[%s] \u2713 All selected checks are passing!", self.task_id)
@@ -724,6 +730,8 @@ class CIOrchestrator(BaseOrchestrator):
             # Re-fetch if not cached (e.g., after restart)
             ci_check_names = json.loads(self.task.get("ci_check_names") or "[]")
             all_failed = get_failed_checks(self.task["pr_number"])
+            if all_failed is None:
+                all_failed = []
             selected = [c for c in all_failed if c["name"] in ci_check_names]
             job_ids = [c["job_id"] for c in selected if c.get("job_id")]
             annotations = get_check_annotations(job_ids)
@@ -765,6 +773,10 @@ class CIOrchestrator(BaseOrchestrator):
                 return "COMPLETE"
 
             states = get_check_states(pr_number, ci_check_names)
+            if states is None:
+                logger.warning("[%s] Could not fetch check states, will retry", self.task_id)
+                time.sleep(poll_interval)
+                continue
 
             # Check if all selected checks have completed
             pending = [n for n, s in states.items() if s not in ("SUCCESS", "FAILURE", "ERROR")]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,13 @@
 """Tests for CLI helpers."""
 
 import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
 from autopilot_loop import persistence
-from autopilot_loop.cli import _check_branch_lock, _validate_task_id, cmd_doctor
+from autopilot_loop.cli import _check_branch_lock, _validate_task_id, cmd_doctor, cmd_fix_ci
 
 
 @pytest.fixture(autouse=True)
@@ -182,3 +184,36 @@ class TestCmdDoctor:
             cmd_doctor(None)
         out = capsys.readouterr().out
         assert "not inside a git repository" in out
+
+
+class TestCmdFixCiErrorHandling:
+    def test_none_checks_prints_error_and_exits(self, capsys, monkeypatch):
+        """When get_failed_checks returns None, cmd_fix_ci should exit 1 with an error."""
+        args = SimpleNamespace(pr=99, model=None, max_iters=None, checks=None)
+
+        # Stub load_config
+        monkeypatch.setattr(
+            "autopilot_loop.cli.load_config",
+            lambda overrides: {"model": "gpt-4", "max_iterations": 5},
+        )
+
+        # Stub PR branch lookup
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="some-branch\n", stderr="",
+            ),
+        )
+
+        # Stub _check_branch_lock to be a no-op
+        monkeypatch.setattr("autopilot_loop.cli._check_branch_lock", lambda b: None)
+
+        # get_failed_checks returns None (API error)
+        with patch("autopilot_loop.github_api.get_failed_checks", return_value=None):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_fix_ci(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "could not fetch CI checks" in captured.err
+        assert "gh auth status" in captured.err

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -229,6 +229,14 @@ class TestGetUnresolvedReviewComments:
             ]
             assert get_unresolved_review_comments(42) == []
 
+    def test_malformed_json_returns_empty(self):
+        with patch("autopilot_loop.github_api._run_gh") as mock_gh:
+            mock_gh.side_effect = [
+                "octocat/hello-world",
+                "not valid json",
+            ]
+            assert get_unresolved_review_comments(42) == []
+
 
 class TestGetIssue:
     def test_returns_issue(self):
@@ -288,6 +296,54 @@ class TestGetFailedChecks:
         assert result[0]["run_id"] is None
         assert result[0]["job_id"] is None
 
+    def test_api_error_tries_rest_fallback(self):
+        with patch("autopilot_loop.github_api._run_gh") as mock_gh:
+            mock_gh.side_effect = [
+                github_api_module.GitHubAPIError("permission error"),  # gh pr checks
+                "abc123",  # pr view for SHA
+                "octocat/hello-world",  # get_repo_nwo
+                json.dumps([{"name": "build", "conclusion": "failure",
+                             "html_url": "https://github.com/o/r/actions/runs/1/job/2"}]),
+            ]
+            result = get_failed_checks(42)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "build"
+
+    def test_api_error_and_rest_fallback_fails_returns_none(self):
+        with patch("autopilot_loop.github_api._run_gh") as mock_gh:
+            mock_gh.side_effect = [
+                github_api_module.GitHubAPIError("permission error"),  # gh pr checks
+                github_api_module.GitHubAPIError("also fails"),  # pr view for SHA
+            ]
+            result = get_failed_checks(42)
+        assert result is None
+
+    def test_malformed_json_tries_rest_fallback(self):
+        with patch("autopilot_loop.github_api._run_gh") as mock_gh:
+            mock_gh.side_effect = [
+                "not valid json",  # gh pr checks returns garbage
+                github_api_module.GitHubAPIError("also fails"),  # rest fallback fails
+            ]
+            result = get_failed_checks(42)
+        assert result is None
+
+    def test_widened_filter_catches_error_state(self):
+        # The jq filter is applied by gh CLI, so in tests we just pass
+        # through whatever the jq filter returns. This test verifies that
+        # non-FAILURE states like ERROR are accepted by _parse_checks.
+        checks_json = json.dumps([
+            {"name": "check-error", "state": "ERROR",
+             "link": "https://github.com/o/r/actions/runs/1/job/2"},
+            {"name": "check-startup", "state": "STARTUP_FAILURE",
+             "link": "https://github.com/o/r/actions/runs/1/job/3"},
+        ])
+        with patch("autopilot_loop.github_api.subprocess.run", return_value=_mock_run(checks_json)):
+            result = get_failed_checks(42)
+        assert len(result) == 2
+        assert result[0]["name"] == "check-error"
+        assert result[1]["name"] == "check-startup"
+
 
 class TestGetCheckAnnotations:
     def test_returns_failure_annotations_deduped(self):
@@ -335,6 +391,21 @@ class TestGetCheckAnnotations:
             mock_gh.side_effect = ["octocat/hello-world", ""]
             assert get_check_annotations([100]) == []
 
+    def test_malformed_json_skips_job(self):
+        good_ann = json.dumps([
+            {"annotation_level": "failure", "path": "test/a.rb", "start_line": 1,
+             "end_line": 1, "title": "Fail", "message": "msg"},
+        ])
+        with patch("autopilot_loop.github_api._run_gh") as mock_gh:
+            mock_gh.side_effect = [
+                "octocat/hello-world",
+                "not valid json",  # job 100 returns garbage
+                good_ann,  # job 200 succeeds
+            ]
+            result = get_check_annotations([100, 200])
+        assert len(result) == 1
+        assert result[0]["path"] == "test/a.rb"
+
 
 class TestGetCheckStates:
     def test_returns_states_for_selected(self):
@@ -348,3 +419,16 @@ class TestGetCheckStates:
         assert result["check-a"] == "SUCCESS"
         assert result["check-b"] == "FAILURE"
         assert result["check-d"] == "UNKNOWN"
+
+    def test_api_error_returns_none(self):
+        with patch("autopilot_loop.github_api.subprocess.run",
+                   return_value=_mock_run("", returncode=1,
+                                          stderr="GraphQL: Resource not accessible")):
+            result = get_check_states(42, ["check-a"])
+        assert result is None
+
+    def test_malformed_json_returns_none(self):
+        with patch("autopilot_loop.github_api.subprocess.run",
+                   return_value=_mock_run("not json")):
+            result = get_check_states(42, ["check-a"])
+        assert result is None


### PR DESCRIPTION
Closes #37

## Problem

`get_failed_checks()` silently swallows API errors and returns an empty list, causing `cmd_fix_ci` to show misleading "No failed CI checks found" when the API actually failed (e.g., due to permission errors like `GraphQL: Resource not accessible by integration`).

## Changes

### 1. Distinguish API errors from empty results
- `get_failed_checks()` now returns `None` on API error (vs `[]` for no failures)
- `cmd_fix_ci` shows an actionable error message when `None` is returned
- Orchestrator callers handle `None` returns gracefully

### 2. REST API fallback
- When `gh pr checks` fails, falls back to the REST check-runs API (`/commits/{sha}/check-runs`)
- Best-effort: works in orgs where REST has different permissions than GraphQL
- If both fail, returns `None`

### 3. Widened state filter
- Changed jq filter from `select(.state == "FAILURE")` to exclude only known-good states (`SUCCESS`, `PENDING`, `SKIPPED`, `EXPECTED`)
- Now catches `ERROR`, `STARTUP_FAILURE`, `CANCELLED`, `TIMED_OUT`, and any future non-passing states

### 4. Hardened other `check=False` calls
- `get_check_states`: returns `None` on API error instead of silent `UNKNOWN` mapping
- `get_check_annotations`: catches `JSONDecodeError` on malformed responses per-job
- `get_unresolved_review_comments`: catches `JSONDecodeError` on malformed GraphQL responses

### 5. Refactoring
- Extracted `_parse_checks()` helper shared between primary and REST fallback paths

## Tests
- API error -> `None` return
- API error + REST fallback succeeds -> returns checks from REST
- API error + REST fallback also fails -> returns `None`
- Malformed JSON -> triggers fallback
- Widened filter accepts `ERROR`/`STARTUP_FAILURE` states
- `cmd_fix_ci` prints actionable error + exits 1 when checks are `None`
- `get_check_states` API error -> `None`
- `get_check_annotations` malformed JSON -> skips job
- `get_unresolved_review_comments` malformed JSON -> empty list
