### PR TITLE
Link autopilot-loop name in review replies

### DIFF
--- a/src/autopilot_loop/orchestrator.py
+++ b/src/autopilot_loop/orchestrator.py
@@ -603,7 +603,7 @@ class Orchestrator(BaseOrchestrator):
             message = summary.get("message", "")
 
             # Build reply
-            PREFIX = "\U0001f916 [autopilot-loop](https://github.com/chanakyav/autopilot-loop)"# Robot emoji for clarity in PR comments
+            PREFIX = "\U0001f916 [autopilot-loop](https://github.com/chanakyav/autopilot-loop)"
             if status == "skipped":
                 reply_body = (
                     "%s: Skipped \u2014 %s" % (PREFIX, message)


### PR DESCRIPTION
## Summary
- make `autopilot-loop` in review replies render as a hyperlink to the project repo
- keep the existing reply wording for addressed/skipped comments

## Testing
- python -m pytest tests/test_orchestrator.py -v
- python -m pytest tests/ -v