### PR TITLE
feat: auto-follow logs after start + remap dashboard keys

### DIFF
--- a/src/autopilot_loop/cli.py
+++ b/src/autopilot_loop/cli.py
@@ -195,6 +195,10 @@ def cmd_start(args):
 
     _launch_in_tmux(task_id, mode="review", branch=branch)
 
+    if not args.no_follow and sys.stdout.isatty():
+        from autopilot_loop.dashboard import logs_tui
+        logs_tui(task_id)
+
 
 def cmd_run(args):
     """Internal: run the orchestrator for a task (called from tmux)."""
@@ -678,6 +682,8 @@ def main():
     p_start.add_argument("--max-iters", type=int, help="Max review-fix iterations")
     p_start.add_argument("--dry-run", action="store_true",
                          help="Show what would run without starting agents or tmux")
+    p_start.add_argument("--no-follow", action="store_true",
+                         help="Don't auto-open log viewer after start")
 
     # resume
     p_resume = subparsers.add_parser("resume", help="Resume from an existing PR")

--- a/src/autopilot_loop/dashboard.py
+++ b/src/autopilot_loop/dashboard.py
@@ -302,9 +302,9 @@ def _build_footer_main():
     footer = Text()
     keys = [
         ("j/k", "navigate"),
-        ("Enter", "attach"),
+        ("Enter", "logs"),
         ("x", "stop"),
-        ("l", "logs"),
+        ("a", "tmux"),
         ("d", "detail"),
         ("r", "refresh"),
         ("q", "quit"),
@@ -324,7 +324,7 @@ def _build_footer_detail():
     keys = [
         ("j/k", "navigate"),
         ("d", "close detail"),
-        ("l", "full logs"),
+        ("Enter", "full logs"),
         ("q", "quit"),
     ]
     for i, (key, action) in enumerate(keys):
@@ -467,6 +467,8 @@ def _read_key(fd, timeout=2.0):
         return "refresh"
     if b == ord("l"):
         return "logs"
+    if b == ord("a"):
+        return "attach"
     if b == ord("d") or b == ord(" "):
         return "detail"
     if b == ord("G"):
@@ -712,6 +714,40 @@ def _logs_view(fd, old_settings, task_id, interval=2):
 
 
 # ---------------------------------------------------------------------------
+# Standalone log viewer (for auto-follow after start)
+# ---------------------------------------------------------------------------
+
+def logs_tui(task_id, interval=2):
+    """Open the full-screen log viewer for a single task.
+
+    Handles terminal setup/teardown. Falls back silently if not a TTY
+    or termios is unavailable.
+    """
+    if not sys.stdin.isatty():
+        return
+
+    try:
+        import termios
+    except ImportError:
+        return
+
+    fd = sys.stdin.fileno()
+    try:
+        old_settings = termios.tcgetattr(fd)
+    except termios.error:
+        return
+
+    try:
+        _enter_tui()
+        _logs_view(fd, old_settings, task_id, interval)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        _exit_tui()
+
+
+# ---------------------------------------------------------------------------
 # Interactive TUI (main entry point)
 # ---------------------------------------------------------------------------
 
@@ -719,7 +755,7 @@ def status_interactive(interval=2):
     """Full-screen interactive dashboard with keybindings.
 
     Features:
-    - j/k navigate, Enter attach, x stop, l logs, d detail, r refresh, q quit
+    - j/k navigate, Enter/l logs, x stop, a tmux, d detail, r refresh, q quit
     - Animated spinners for active states
     - Detail panel toggle showing task metadata + log tail
     - Full log viewer with j/k scroll
@@ -823,7 +859,17 @@ def status_interactive(interval=2):
                 if tasks:
                     selected = max(selected - 1, 0)
 
-            elif key == "enter":
+            elif key == "enter" or key == "logs":
+                tasks = list_tasks()
+                if tasks and 0 <= selected < len(tasks):
+                    msg = _logs_view(fd, old_settings, tasks[selected]["id"], interval)
+                    if msg:
+                        set_status(msg)
+                    # Full clear after returning from log viewer
+                    sys.stdout.write(_CLEAR_SCREEN)
+                    sys.stdout.flush()
+
+            elif key == "attach":
                 tasks = list_tasks()
                 if tasks and 0 <= selected < len(tasks):
                     msg = _do_attach(tasks[selected])
@@ -840,16 +886,6 @@ def status_interactive(interval=2):
                 detail_open = not detail_open
                 sys.stdout.write(_CLEAR_SCREEN)
                 sys.stdout.flush()
-
-            elif key == "logs":
-                tasks = list_tasks()
-                if tasks and 0 <= selected < len(tasks):
-                    msg = _logs_view(fd, old_settings, tasks[selected]["id"], interval)
-                    if msg:
-                        set_status(msg)
-                    # Full clear after returning from log viewer
-                    sys.stdout.write(_CLEAR_SCREEN)
-                    sys.stdout.flush()
 
             elif key == "refresh":
                 set_status("Refreshed")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -217,3 +217,94 @@ class TestCmdFixCiErrorHandling:
         captured = capsys.readouterr()
         assert "could not fetch CI checks" in captured.err
         assert "gh auth status" in captured.err
+
+
+class TestCmdStartFollow:
+    """Test auto-follow behavior after autopilot start."""
+
+    def _make_args(self, **overrides):
+        defaults = {
+            "prompt": "test prompt",
+            "issue": None,
+            "plan": False,
+            "model": None,
+            "max_iters": None,
+            "dry_run": False,
+            "no_follow": False,
+        }
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def _stub_start_deps(self, monkeypatch):
+        """Stub all cmd_start dependencies so it doesn't hit real systems."""
+        monkeypatch.setattr(
+            "autopilot_loop.cli.load_config",
+            lambda overrides: {
+                "model": "test-model",
+                "max_iterations": 3,
+                "branch_pattern": "autopilot/{task_id}",
+            },
+        )
+        monkeypatch.setattr("autopilot_loop.cli._detect_autopilot_branch", lambda: None)
+        monkeypatch.setattr("autopilot_loop.cli._check_branch_lock", lambda b: None)
+        monkeypatch.setattr("autopilot_loop.cli._launch_in_tmux", lambda *a, **kw: None)
+
+    def test_follow_calls_logs_tui(self, monkeypatch):
+        """When --no-follow is absent and stdout is a TTY, logs_tui is called."""
+        self._stub_start_deps(monkeypatch)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+        calls = []
+        monkeypatch.setattr(
+            "autopilot_loop.dashboard.logs_tui",
+            lambda task_id: calls.append(task_id),
+        )
+
+        from autopilot_loop.cli import cmd_start
+        cmd_start(self._make_args())
+        assert len(calls) == 1
+
+    def test_no_follow_skips_logs_tui(self, monkeypatch):
+        """When --no-follow is set, logs_tui is NOT called."""
+        self._stub_start_deps(monkeypatch)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+        calls = []
+        monkeypatch.setattr(
+            "autopilot_loop.dashboard.logs_tui",
+            lambda task_id: calls.append(task_id),
+        )
+
+        from autopilot_loop.cli import cmd_start
+        cmd_start(self._make_args(no_follow=True))
+        assert len(calls) == 0
+
+    def test_non_tty_skips_logs_tui(self, monkeypatch):
+        """When stdout is not a TTY, logs_tui is NOT called."""
+        self._stub_start_deps(monkeypatch)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+
+        calls = []
+        monkeypatch.setattr(
+            "autopilot_loop.dashboard.logs_tui",
+            lambda task_id: calls.append(task_id),
+        )
+
+        from autopilot_loop.cli import cmd_start
+        cmd_start(self._make_args())
+        assert len(calls) == 0
+
+    def test_dry_run_skips_logs_tui(self, monkeypatch, capsys):
+        """When --dry-run is set, logs_tui is NOT called."""
+        self._stub_start_deps(monkeypatch)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+        calls = []
+        monkeypatch.setattr(
+            "autopilot_loop.dashboard.logs_tui",
+            lambda task_id: calls.append(task_id),
+        )
+
+        from autopilot_loop.cli import cmd_start
+        cmd_start(self._make_args(dry_run=True))
+        assert len(calls) == 0

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -22,6 +22,7 @@ from autopilot_loop.dashboard import (
     _get_indicator,
     _read_key,
     _read_log_tail,
+    logs_tui,
 )
 
 
@@ -187,13 +188,19 @@ class TestFooters:
     def test_main_footer_has_all_keys(self):
         footer = _build_footer_main()
         text = str(footer)
-        for key in ["j/k", "Enter", "x", "l", "d", "r", "q"]:
+        for key in ["j/k", "Enter", "x", "a", "d", "r", "q"]:
             assert key in text
+        assert "logs" in text
+        assert "tmux" in text
+        # "attach" should no longer appear in footer
+        assert "attach" not in text
 
     def test_detail_footer_has_close(self):
         footer = _build_footer_detail()
         text = str(footer)
         assert "close" in text
+        assert "Enter" in text
+        assert "full logs" in text
 
     def test_logs_footer_has_scroll(self):
         footer = _build_footer_logs()
@@ -395,3 +402,47 @@ class TestMakeConsole:
         from autopilot_loop.dashboard import _make_console
         console = _make_console()
         assert console.no_color is True
+
+
+class TestReadKeyAttach:
+    def test_a_returns_attach(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"a")
+            result = _read_key(r, timeout=0.1)
+            assert result == "attach"
+        finally:
+            os.close(r)
+            os.close(w)
+
+
+class TestLogsTui:
+    def test_non_tty_returns_immediately(self, monkeypatch):
+        """logs_tui should return without error when stdin is not a TTY."""
+        monkeypatch.setattr("sys.stdin", open(os.devnull))
+        # Should not raise
+        logs_tui("fake-id")
+
+    def test_calls_logs_view(self, monkeypatch):
+        """logs_tui should call _logs_view with correct args."""
+        calls = []
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("sys.stdin.fileno", lambda: 0)
+
+        # Stub termios/tty operations and TUI enter/exit
+        import autopilot_loop.dashboard as dash
+        monkeypatch.setattr(dash, "_enter_tui", lambda: None)
+        monkeypatch.setattr(dash, "_exit_tui", lambda: None)
+
+        import termios
+        monkeypatch.setattr(termios, "tcgetattr", lambda fd: [])
+        monkeypatch.setattr(termios, "tcsetattr", lambda fd, w, s: None)
+
+        def fake_logs_view(fd, old_settings, task_id, interval):
+            calls.append((task_id, interval))
+            return None
+
+        monkeypatch.setattr(dash, "_logs_view", fake_logs_view)
+        logs_tui("abc12345", interval=3)
+        assert calls == [("abc12345", 3)]


### PR DESCRIPTION
## Summary

After `autopilot start`, automatically open the TUI log viewer for the new task instead of returning to a silent shell. Remap dashboard keybindings so `Enter` opens logs and `a` attaches to tmux.

Closes #41, Closes #43

## Changes

### Auto-follow logs after start (#41)
- `cmd_start()` now calls `logs_tui(task_id)` after launching the tmux session
- New `logs_tui()` public function in `dashboard.py` — standalone TUI log viewer with proper terminal setup/teardown (`_enter_tui`/`_exit_tui` in `finally` block)
- Added `--no-follow` flag for scripts/CI that want fire-and-forget behavior
- Gracefully skips when not a TTY or termios unavailable

### Dashboard keybinding remap (#43)
- `Enter` opens log viewer (was: attach to tmux)
- `a` attaches to tmux, labeled "tmux" in footer (new key)
- `l` still works for logs (muscle memory) but removed from footer since `Enter` does the same
- Detail view footer: `Enter` → "full logs" (was: `l`)
- Updated `status_interactive()` docstring

### Tests
- `test_a_returns_attach` — new `a` key mapping in `_read_key`
- `test_main_footer_has_all_keys` — updated: asserts `logs`/`tmux` labels, no `attach`
- `test_detail_footer_has_close` — updated: asserts `Enter` → "full logs"
- `TestLogsTui` — non-TTY fallback + correct `_logs_view` delegation
- `TestCmdStartFollow` — 4 tests: follow, no-follow, non-TTY, dry-run

## Keybinding cheat sheet (before / after)

| Key | Before | After |
|-----|--------|-------|
| `Enter` | attach (tmux) | **logs** |
| `l` | logs | logs (unchanged, removed from footer) |
| `a` | *(unmapped)* | **tmux** (attach) |

## Verification
- `ruff check src/ tests/` — zero errors
- `pytest tests/` — 192 passed
