### PR TITLE
fix: validate repo in cmd_resume to prevent wrong-repo resumption

### DIFF
--- a/src/autopilot_loop/cli.py
+++ b/src/autopilot_loop/cli.py
@@ -241,13 +241,25 @@ def cmd_resume(args):
     try:
         result = subprocess.run(
             ["gh", "pr", "view", str(args.pr),
-             "--json", "headRefName,state",
-             "--jq", '[.headRefName, .state] | @tsv'],
+             "--json", "headRefName,state,headRepository",
+             "--jq", '[.headRefName, .state, .headRepository.nameWithOwner] | @tsv'],
             capture_output=True, text=True, check=True,
         )
         parts = result.stdout.strip().split("\t")
         branch = parts[0]
         pr_state = parts[1] if len(parts) > 1 else "UNKNOWN"
+        pr_repo = parts[2] if len(parts) > 2 else ""
+
+        # Ensure the PR belongs to the current repo
+        from autopilot_loop.github_api import get_repo_nwo
+        local_nwo = get_repo_nwo()
+        if pr_repo and pr_repo != local_nwo:
+            print(
+                "Error: PR #%d belongs to %s, but you're in %s"
+                % (args.pr, pr_repo, local_nwo),
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
         if pr_state != "OPEN":
             print("Error: PR #%d is %s (must be OPEN to resume)" % (args.pr, pr_state),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,13 @@ from unittest.mock import patch
 import pytest
 
 from autopilot_loop import persistence
-from autopilot_loop.cli import _check_branch_lock, _validate_task_id, cmd_doctor, cmd_fix_ci
+from autopilot_loop.cli import (
+    _check_branch_lock,
+    _validate_task_id,
+    cmd_doctor,
+    cmd_fix_ci,
+    cmd_resume,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -308,3 +314,108 @@ class TestCmdStartFollow:
         from autopilot_loop.cli import cmd_start
         cmd_start(self._make_args(dry_run=True))
         assert len(calls) == 0
+
+
+class TestCmdResumeRepoValidation:
+    """Test that cmd_resume rejects PRs from a different repo."""
+
+    def _gh_pr_view_output(self, branch, state, nwo):
+        """Build the tsv output that gh pr view would return."""
+        return "%s\t%s\t%s\n" % (branch, state, nwo)
+
+    def test_wrong_repo_exits(self, monkeypatch, capsys):
+        """cmd_resume should exit 1 when the PR belongs to a different repo."""
+        monkeypatch.setattr(
+            "autopilot_loop.cli.load_config",
+            lambda **kw: {"model": "m", "max_iterations": 3},
+        )
+        monkeypatch.setattr(
+            "autopilot_loop.github_api.get_repo_nwo",
+            lambda: "owner/my-repo",
+        )
+
+        def fake_run(cmd, **kw):
+            if "pr" in cmd and "view" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0,
+                    stdout=self._gh_pr_view_output(
+                        "some-branch", "OPEN", "other-owner/other-repo",
+                    ),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        args = SimpleNamespace(pr=999)
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_resume(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "other-owner/other-repo" in captured.err
+        assert "owner/my-repo" in captured.err
+
+    def test_same_repo_passes_validation(self, monkeypatch):
+        """cmd_resume should NOT exit when the PR belongs to the current repo."""
+        monkeypatch.setattr(
+            "autopilot_loop.cli.load_config",
+            lambda **kw: {"model": "m", "max_iterations": 3},
+        )
+        monkeypatch.setattr(
+            "autopilot_loop.github_api.get_repo_nwo",
+            lambda: "owner/my-repo",
+        )
+        monkeypatch.setattr("autopilot_loop.cli._check_branch_lock", lambda b: None)
+        monkeypatch.setattr("autopilot_loop.cli._launch_in_tmux", lambda *a, **kw: None)
+
+        def fake_run(cmd, **kw):
+            if "pr" in cmd and "view" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0,
+                    stdout=self._gh_pr_view_output(
+                        "fix/something", "OPEN", "owner/my-repo",
+                    ),
+                    stderr="",
+                )
+            # git checkout
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        args = SimpleNamespace(pr=42)
+        # Should not raise
+        cmd_resume(args)
+
+    def test_merged_pr_wrong_repo_exits_with_repo_error(self, monkeypatch, capsys):
+        """A merged PR from a different repo should fail on repo mismatch, not state."""
+        monkeypatch.setattr(
+            "autopilot_loop.cli.load_config",
+            lambda **kw: {"model": "m", "max_iterations": 3},
+        )
+        monkeypatch.setattr(
+            "autopilot_loop.github_api.get_repo_nwo",
+            lambda: "owner/my-repo",
+        )
+
+        def fake_run(cmd, **kw):
+            if "pr" in cmd and "view" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0,
+                    stdout=self._gh_pr_view_output(
+                        "some-branch", "MERGED", "other-owner/other-repo",
+                    ),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        args = SimpleNamespace(pr=16173)
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_resume(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        # Should fail on repo mismatch BEFORE checking state
+        assert "other-owner/other-repo" in captured.err


### PR DESCRIPTION
## Problem

Running `autopilot resume --pr <N>` in the wrong repo can accidentally resume a PR that belongs to a completely different project. `gh pr view <N>` is repo-scoped, so if PR #N happens to exist in the wrong repo and is open, `cmd_resume` would proceed to check out its branch and start a task.

Example: running `autopilot resume --pr 16173` in `autopilot-loop` when the PR actually belongs to another repo.

## Fix

`cmd_resume` now queries `headRepository.nameWithOwner` from the PR metadata and compares it against the local repo's NWO (via `get_repo_nwo()`). If they don't match, it exits immediately with a clear error:

```
Error: PR #16173 belongs to other-owner/other-repo, but you're in owner/my-repo
```

The repo validation runs **before** the state check, so a wrong-repo PR is caught regardless of whether it's open, merged, or closed.

## Changes

- **`src/autopilot_loop/cli.py`** — `cmd_resume()`: query `headRepository` in `gh pr view`, validate NWO match before proceeding
- **`tests/test_cli.py`** — 3 new tests:
  - `test_wrong_repo_exits` — wrong NWO → exit 1 with clear error
  - `test_same_repo_passes_validation` — matching NWO proceeds normally
  - `test_merged_pr_wrong_repo_exits_with_repo_error` — repo mismatch caught before state check
