### PR TITLE
Fix review detection: use timestamp instead of ID

### DIFF
--- a/src/autopilot_loop/github_api.py
+++ b/src/autopilot_loop/github_api.py
@@ -126,15 +126,11 @@ def request_copilot_review(pr_number):
     logger.info("Requested Copilot review on PR #%d", pr_number)
 
 
-def get_copilot_review(pr_number, after_id=None):
+def get_copilot_review(pr_number):
     """Get the latest Copilot review for a PR.
 
-    Args:
-        pr_number: PR number.
-        after_id: If set, only return a review with id > after_id.
-
     Returns:
-        Dict with review data, or None if no matching Copilot review exists.
+        Dict with review data (including id and submitted_at), or None.
     """
     nwo = get_repo_nwo()
     output = _run_gh([
@@ -145,25 +141,28 @@ def get_copilot_review(pr_number, after_id=None):
     if not output or output == "null":
         return None
 
-    review = json.loads(output)
-    if after_id and review.get("id", 0) <= after_id:
-        return None
-
-    return review
+    return json.loads(output)
 
 
-def is_copilot_review_complete(pr_number, after_id=None):
-    """Check if Copilot has submitted a new review.
+def is_copilot_review_complete(pr_number, after_ts=None):
+    """Check if Copilot has submitted a new or updated review.
 
     Args:
         pr_number: PR number.
-        after_id: If set, only returns True for reviews with id > after_id.
+        after_ts: If set, only returns True for reviews submitted after this
+                  ISO 8601 timestamp. This handles both new reviews (higher ID)
+                  and updated reviews (same ID but newer submitted_at).
 
     Returns:
-        True if a new Copilot review is present.
+        True if a new/updated Copilot review is present.
     """
-    review = get_copilot_review(pr_number, after_id=after_id)
-    return review is not None
+    review = get_copilot_review(pr_number)
+    if review is None:
+        return False
+    if after_ts is None:
+        return True
+    submitted = review.get("submitted_at", "")
+    return submitted > after_ts
 
 
 def get_issue(issue_number):

--- a/src/autopilot_loop/orchestrator.py
+++ b/src/autopilot_loop/orchestrator.py
@@ -268,7 +268,7 @@ class Orchestrator(BaseOrchestrator):
 
     def __init__(self, task_id, config):
         super().__init__(task_id, config)
-        self._last_review_id = self.task.get("last_review_id")  # restore from DB
+        self._last_review_ts = None  # timestamp-based review detection
 
     def _get_handlers(self):
         return {
@@ -299,13 +299,12 @@ class Orchestrator(BaseOrchestrator):
         """Run copilot agent with implement prompt."""
         branch = self.task["branch"]
 
-        # Snapshot review ID before the agent pushes (same pattern as _do_fix)
+        # Snapshot review timestamp before the agent pushes (same pattern as _do_fix)
         pr_number = self.task.get("pr_number")
         if pr_number:
             current_review = get_copilot_review(pr_number)
             if current_review:
-                self._last_review_id = current_review.get("id", 0)
-                update_task(self.task_id, last_review_id=self._last_review_id)
+                self._last_review_ts = current_review.get("submitted_at", "")
 
         # Use existing-branch prompt if the branch already exists remotely
         if self.task.get("existing_branch"):
@@ -420,7 +419,7 @@ class Orchestrator(BaseOrchestrator):
                 )
                 return "COMPLETE"
 
-            if is_copilot_review_complete(pr_number, after_id=self._last_review_id):
+            if is_copilot_review_complete(pr_number, after_ts=self._last_review_ts):
                 logger.info("[%s] ✓ Copilot review received", self.task_id)
                 return "PARSE_REVIEW"
 
@@ -546,14 +545,13 @@ class Orchestrator(BaseOrchestrator):
         # Record head SHA before fix
         self._pre_fix_sha = get_head_sha(self.task["branch"])
 
-        # Snapshot the current latest review ID BEFORE the agent pushes,
-        # so any review that arrives after the push (auto-triggered or
-        # explicitly requested) has a higher ID than the snapshot.
+        # Snapshot the review timestamp BEFORE the agent pushes,
+        # so any review arriving after the push (auto-triggered or
+        # explicitly requested) has a newer submitted_at timestamp.
         current_review = get_copilot_review(pr_number)
         if current_review:
-            self._last_review_id = current_review.get("id", 0)
-            update_task(self.task_id, last_review_id=self._last_review_id)
-            logger.debug("[%s] Snapshot review ID before fix: %s", self.task_id, self._last_review_id)
+            self._last_review_ts = current_review.get("submitted_at", "")
+            logger.debug("[%s] Snapshot review timestamp before fix: %s", self.task_id, self._last_review_ts)
 
         result = self._run_agent_with_retry("FIX", prompt, "fix-%d" % iteration)
         if result is None:

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -15,6 +15,7 @@ from autopilot_loop.github_api import (
     get_issue,
     get_repo_nwo,
     get_unresolved_review_comments,
+    is_copilot_review_complete,
     reply_to_comment,
     request_copilot_review,
     resolve_review_thread,
@@ -99,25 +100,26 @@ class TestGetCopilotReview:
             ]
             assert get_copilot_review(42) is None
 
-    def test_after_id_filters_old(self):
-        review_data = {"id": 100, "body": "old review", "state": "COMMENTED"}
+    def test_after_ts_filters_old(self):
+        review_data = {"id": 100, "body": "old review", "state": "COMMENTED",
+                       "submitted_at": "2026-03-18T08:00:00Z"}
         with patch("autopilot_loop.github_api._run_gh") as mock_gh:
             mock_gh.side_effect = [
                 "octocat/hello-world",
                 json.dumps(review_data),
             ]
-            # Review id 100 is not > after_id 100
-            assert get_copilot_review(42, after_id=100) is None
+            # Same timestamp means not newer
+            assert is_copilot_review_complete(42, after_ts="2026-03-18T08:00:00Z") is False
 
-    def test_after_id_allows_new(self):
-        review_data = {"id": 200, "body": "new review", "state": "COMMENTED"}
+    def test_after_ts_allows_new(self):
+        review_data = {"id": 200, "body": "new review", "state": "COMMENTED",
+                       "submitted_at": "2026-03-18T09:00:00Z"}
         with patch("autopilot_loop.github_api._run_gh") as mock_gh:
             mock_gh.side_effect = [
                 "octocat/hello-world",
                 json.dumps(review_data),
             ]
-            result = get_copilot_review(42, after_id=100)
-            assert result == review_data
+            assert is_copilot_review_complete(42, after_ts="2026-03-18T08:00:00Z") is True
 
 
 class TestReplyToComment:


### PR DESCRIPTION
Copilot can update reviews in-place (same ID, new `submitted_at`) rather than creating a new review with a higher ID. Our ID-based detection missed these updates, causing `WAIT_REVIEW` to poll indefinitely.

Supersedes #61 which moved the snapshot earlier but still used IDs.

### Root Cause

After the agent pushes fixes, Copilot re-reviews the PR. But instead of creating a new review (higher ID), it can **update the existing review** — same ID, but with a new `submitted_at` timestamp and new comments.

Our detection (`review.id > last_review_id`) returned `False` because the IDs were identical.

### Fix

Switch from ID-based to **timestamp-based** detection:
- `get_copilot_review()` no longer takes `after_id`
- `is_copilot_review_complete()` takes `after_ts` (ISO 8601 timestamp string)
- Orchestrator snapshots `submitted_at` before agent runs
- String comparison on ISO 8601 timestamps correctly detects newer reviews

### Verified

Production data confirmed: review ID stayed at `3968766752` across multiple review cycles, but `submitted_at` changed each time. The new logic correctly detects these updates.
