### PR TITLE
Rework review detection: poll for unresolved comments

### DIFF
--- a/src/autopilot_loop/orchestrator.py
+++ b/src/autopilot_loop/orchestrator.py
@@ -23,7 +23,6 @@ from autopilot_loop.github_api import (
     get_failed_checks,
     get_head_sha,
     get_unresolved_review_comments,
-    is_copilot_review_complete,
     reply_to_comment,
     request_copilot_review,
     resolve_review_thread,
@@ -268,7 +267,6 @@ class Orchestrator(BaseOrchestrator):
 
     def __init__(self, task_id, config):
         super().__init__(task_id, config)
-        self._last_review_ts = None  # timestamp-based review detection
 
     def _get_handlers(self):
         return {
@@ -298,13 +296,6 @@ class Orchestrator(BaseOrchestrator):
     def _do_implement(self):
         """Run copilot agent with implement prompt."""
         branch = self.task["branch"]
-
-        # Snapshot review timestamp before the agent pushes (same pattern as _do_fix)
-        pr_number = self.task.get("pr_number")
-        if pr_number:
-            current_review = get_copilot_review(pr_number)
-            if current_review:
-                self._last_review_ts = current_review.get("submitted_at", "")
 
         # Use existing-branch prompt if the branch already exists remotely
         if self.task.get("existing_branch"):
@@ -401,14 +392,21 @@ class Orchestrator(BaseOrchestrator):
         return "WAIT_REVIEW"
 
     def _do_wait_review(self):
-        """Poll for Copilot review completion."""
+        """Poll for new unresolved Copilot review comments.
+
+        After RESOLVE_COMMENTS resolves all threads and REQUEST_REVIEW
+        requests a fresh review, we poll for new unresolved comments.
+        A minimum initial wait gives Copilot time to start reviewing.
+        """
         pr_number = self.task["pr_number"]
         poll_interval = self.config.get("review_poll_interval_seconds", 60)
         timeout = self.config.get("review_timeout_seconds", 3600)
+        min_wait = min(poll_interval, 60)
         start_time = time.time()
 
-        logger.info("[%s] Polling every %ds for Copilot review (timeout: %ds)...",
-                    self.task_id, poll_interval, timeout)
+        logger.info("[%s] Waiting %ds before first poll, then every %ds (timeout: %ds)...",
+                    self.task_id, min_wait, poll_interval, timeout)
+        time.sleep(min_wait)
 
         while True:
             elapsed = time.time() - start_time
@@ -419,11 +417,18 @@ class Orchestrator(BaseOrchestrator):
                 )
                 return "COMPLETE"
 
-            if is_copilot_review_complete(pr_number, after_ts=self._last_review_ts):
-                logger.info("[%s] ✓ Copilot review received", self.task_id)
+            comments = get_unresolved_review_comments(pr_number)
+            if comments:
+                logger.info("[%s] ✓ Found %d unresolved Copilot comments",
+                            self.task_id, len(comments))
                 return "PARSE_REVIEW"
 
-            logger.debug("[%s] No review yet, waiting %ds... (%.0f/%ds elapsed)",
+            review = get_copilot_review(pr_number)
+            if review and review.get("state") == "APPROVED":
+                logger.info("[%s] ✓ Copilot approved the PR", self.task_id)
+                return "COMPLETE"
+
+            logger.debug("[%s] No new comments yet, waiting %ds... (%.0f/%ds elapsed)",
                          self.task_id, poll_interval, elapsed, timeout)
             time.sleep(poll_interval)
 
@@ -544,14 +549,6 @@ class Orchestrator(BaseOrchestrator):
 
         # Record head SHA before fix
         self._pre_fix_sha = get_head_sha(self.task["branch"])
-
-        # Snapshot the review timestamp BEFORE the agent pushes,
-        # so any review arriving after the push (auto-triggered or
-        # explicitly requested) has a newer submitted_at timestamp.
-        current_review = get_copilot_review(pr_number)
-        if current_review:
-            self._last_review_ts = current_review.get("submitted_at", "")
-            logger.debug("[%s] Snapshot review timestamp before fix: %s", self.task_id, self._last_review_ts)
 
         result = self._run_agent_with_retry("FIX", prompt, "fix-%d" % iteration)
         if result is None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -102,9 +102,9 @@ class TestOrchestratorVerifyPR:
 
 
 class TestOrchestratorWaitReview:
-    @patch("autopilot_loop.orchestrator.is_copilot_review_complete")
-    def test_review_received(self, mock_check, config):
-        mock_check.return_value = True
+    @patch("autopilot_loop.orchestrator.get_unresolved_review_comments")
+    def test_review_received(self, mock_comments, config):
+        mock_comments.return_value = [{"id": 1, "thread_id": "T1", "path": "a.rb", "body": "fix"}]
         task_id = _create_test_task()
         persistence.update_task(task_id, pr_number=42)
         orch = Orchestrator(task_id, config)
@@ -112,9 +112,11 @@ class TestOrchestratorWaitReview:
         assert orch._do_wait_review() == "PARSE_REVIEW"
 
     @patch("autopilot_loop.orchestrator.time.sleep")
-    @patch("autopilot_loop.orchestrator.is_copilot_review_complete")
-    def test_review_timeout(self, mock_check, mock_sleep, config):
-        mock_check.return_value = False
+    @patch("autopilot_loop.orchestrator.get_copilot_review")
+    @patch("autopilot_loop.orchestrator.get_unresolved_review_comments")
+    def test_review_timeout(self, mock_comments, mock_review, mock_sleep, config):
+        mock_comments.return_value = []
+        mock_review.return_value = {"id": 100, "state": "COMMENTED"}
         config["review_timeout_seconds"] = 0  # Immediate timeout
         task_id = _create_test_task()
         persistence.update_task(task_id, pr_number=42)
@@ -127,7 +129,7 @@ class TestOrchestratorParseReview:
     @patch("autopilot_loop.orchestrator.get_unresolved_review_comments")
     @patch("autopilot_loop.orchestrator.get_copilot_review")
     def test_no_comments_completes(self, mock_review, mock_unresolved, config, tmp_path):
-        mock_review.return_value = {"id": 100, "body": "LGTM"}
+        mock_review.return_value = {"id": 100, "body": "LGTM", "state": "APPROVED"}
         mock_unresolved.return_value = []
         task_id = _create_test_task()
         persistence.update_task(task_id, pr_number=42)
@@ -182,7 +184,6 @@ class TestOrchestratorFullLoop:
     @patch("autopilot_loop.orchestrator.reply_to_comment")
     @patch("autopilot_loop.orchestrator.verify_new_commits")
     @patch("autopilot_loop.orchestrator.get_head_sha")
-    @patch("autopilot_loop.orchestrator.is_copilot_review_complete")
     @patch("autopilot_loop.orchestrator.request_copilot_review")
     @patch("autopilot_loop.orchestrator.get_unresolved_review_comments")
     @patch("autopilot_loop.orchestrator.get_copilot_review")
@@ -190,16 +191,15 @@ class TestOrchestratorFullLoop:
     @patch("autopilot_loop.orchestrator.run_agent")
     def test_clean_pr_no_comments(
         self, mock_run, mock_find_pr, mock_review, mock_unresolved,
-        mock_request, mock_is_complete, mock_sha, mock_verify,
+        mock_request, mock_sha, mock_verify,
         mock_reply, mock_resolve, mock_timeout,
         config,
     ):
         """Full loop: implement → verify PR → request review → wait → parse → COMPLETE."""
         mock_run.return_value = _mock_agent_result()
         mock_find_pr.return_value = 42
-        mock_review.return_value = {"id": 100, "body": "LGTM"}
+        mock_review.return_value = {"id": 100, "body": "LGTM", "state": "APPROVED"}
         mock_unresolved.return_value = []
-        mock_is_complete.return_value = True
 
         task_id = _create_test_task()
         orch = Orchestrator(task_id, config)
@@ -211,7 +211,6 @@ class TestOrchestratorFullLoop:
     @patch("autopilot_loop.orchestrator.reply_to_comment")
     @patch("autopilot_loop.orchestrator.verify_new_commits")
     @patch("autopilot_loop.orchestrator.get_head_sha")
-    @patch("autopilot_loop.orchestrator.is_copilot_review_complete")
     @patch("autopilot_loop.orchestrator.request_copilot_review")
     @patch("autopilot_loop.orchestrator.get_unresolved_review_comments")
     @patch("autopilot_loop.orchestrator.get_copilot_review")
@@ -219,23 +218,27 @@ class TestOrchestratorFullLoop:
     @patch("autopilot_loop.orchestrator.run_agent")
     def test_one_fix_iteration(
         self, mock_run, mock_find_pr, mock_review, mock_unresolved,
-        mock_request, mock_is_complete, mock_sha, mock_verify,
+        mock_request, mock_sha, mock_verify,
         mock_reply, mock_resolve, mock_timeout,
         config,
     ):
         """Full loop with one fix iteration: comments → fix → resolve → re-review → clean."""
         mock_run.return_value = _mock_agent_result()
         mock_find_pr.return_value = 42
-        mock_is_complete.return_value = True
         mock_sha.return_value = "sha1"
         mock_verify.return_value = True
 
         # First pass: 1 unresolved comment. After fix+resolve: 0 unresolved.
-        mock_review.return_value = {"id": 100, "body": "review"}
+        # WAIT_REVIEW now also polls get_unresolved, so extra entries needed.
+        mock_review.return_value = {"id": 100, "body": "review", "state": "APPROVED"}
+        _comment = {"id": 1, "thread_id": "T1", "path": "a.rb", "line": 10, "body": "fix this"}
         mock_unresolved.side_effect = [
-            [{"id": 1, "thread_id": "T1", "path": "a.rb", "line": 10, "body": "fix this"}],
-            [{"id": 1, "thread_id": "T1", "path": "a.rb", "line": 10, "body": "fix this"}],
-            [],
+            [_comment],  # WAIT_REVIEW 1st cycle: found comments
+            [_comment],  # PARSE_REVIEW
+            [_comment],  # _do_fix
+            [_comment],  # RESOLVE_COMMENTS
+            [],          # WAIT_REVIEW 2nd cycle: clean
+            [],          # PARSE_REVIEW 2nd: confirms clean
         ]
 
         task_id = _create_test_task()
@@ -256,7 +259,7 @@ class TestOrchestratorFullLoop:
         self, mock_review, mock_unresolved, mock_timeout, config,
     ):
         """Resume skips REQUEST_REVIEW and goes straight to PARSE_REVIEW."""
-        mock_review.return_value = {"id": 100, "body": "LGTM"}
+        mock_review.return_value = {"id": 100, "body": "LGTM", "state": "APPROVED"}
         mock_unresolved.return_value = []
 
         task_id = _create_test_task()


### PR DESCRIPTION
The previous review detection approaches (ID-based in #61, timestamp-based in #62) both failed because Copilot can add new inline comments **without updating the review object itself**. The review metadata (id, submitted_at) stays the same even when new comments are added.

### New Approach: Poll for Unresolved Comments

Instead of trying to detect "a new review," we now detect what actually matters: **are there unresolved Copilot comments?**

`WAIT_REVIEW` now:
1. Waits a minimum of 60 seconds (gives Copilot time to start reviewing)
2. Polls `get_unresolved_review_comments(pr_number)` — if comments found, proceed to PARSE_REVIEW
3. Also checks `review.state == "APPROVED"` for the clean-review case (no comments)
4. Times out after `review_timeout_seconds` as before

### What This Fixes
- Review ID staying the same across review cycles (Copilot updates in-place)
- `submitted_at` not changing when new inline comments are added
- WAIT_REVIEW polling indefinitely despite new comments being visible on the PR

### Removed
- `is_copilot_review_complete()` no longer used by orchestrator
- Review ID/timestamp snapshot logic in `_do_fix` and `_do_implement`
- `_last_review_ts` field on Orchestrator

All 197 tests pass.
